### PR TITLE
style: [알림함] - 기기 알림꺼짐 배너 UI 깨짐 수정 🟡

### DIFF
--- a/Keychy/Keychy/Presentation/Home/Views/Alarm/AlarmView.swift
+++ b/Keychy/Keychy/Presentation/Home/Views/Alarm/AlarmView.swift
@@ -76,10 +76,13 @@ extension AlarmView {
             // 푸시 알림 off 배너
             if viewModel.isNotiOff && viewModel.isNotiOffShown {
                 pushNotiOffView
+                    .listRowInsets(.init())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
                     .padding(.top, 10)
                     .padding(.bottom, 20)
             }
-
+            
             ForEach(viewModel.notifications) { notification in
                 NotificationItemView(
                     notification: notification,

--- a/Keychy/Keychy/Presentation/Home/Views/Alarm/AlarmView.swift
+++ b/Keychy/Keychy/Presentation/Home/Views/Alarm/AlarmView.swift
@@ -41,7 +41,7 @@ struct AlarmView: View {
                 viewModel.hasNetworkError = true
                 return
             }
-
+            
             viewModel.checkNotificationPermission()
             viewModel.fetchNotifications()
         }
@@ -69,7 +69,7 @@ extension AlarmView {
         })
         .ignoresSafeArea()
     }
-
+    
     /// 알림 리스트 뷰
     private var notificationListView: some View {
         List {
@@ -90,7 +90,7 @@ extension AlarmView {
                         handleNotificationTap(notification)
                     }
                 )
-                .listRowInsets(EdgeInsets())
+                .listRowInsets(.init())
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
@@ -114,7 +114,7 @@ extension AlarmView {
                 .typography(.suit15R)
                 .padding(15)
         }
-
+        
     }
     
     /// 기기 푸쉬 알림이 off일 때 나오는 상단뷰


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->
<img width="350" alt="알림함 레이아웃 조정 전" src="https://github.com/user-attachments/assets/e30a186f-f567-49d9-a952-785baf2c881e" />

**위 사진처럼, 알림함 알림 설정 배너 UI가 이상해보이는 문제가 있었습니다.**

해결은 간단했습니다. 

```swift
List {
    // 푸시 알림 off 배너
    if viewModel.isNotiOff && viewModel.isNotiOffShown {
        pushNotiOffView
			.listRowInsets(.init())
			.listRowSeparator(.hidden)
			.listRowBackground(Color.clear)
			.padding(.top, 10)
			.padding(.bottom, 20)
}
```

> **list 기본 스타일을 제거하고 보여줬던, 알림 아이템뷰들.**
**그런데, 알림설정 배너에는 이 list 모디파이어들이 적용되지 않았었습니다.**

- List 내부에 커스텀 뷰를 그대로 넣으면, 기본 row inset / separator가 적용됨.
- 각 row에 .listRowInsets(.init()), .listRowSeparator(.hidden),  .listRowBackground(.clear)를 적용. 
알림 배너뷰에도 List 기본 스타일을 제거하고 의도한 레이아웃으로 정렬되도록 수정.

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

https://github.com/user-attachments/assets/56570947-981f-4f69-8d42-04a49076772c


## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #4 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
