### PR TITLE
Bugfix: [키링 만들기] - 키링 제작 중간에 뒤로가기로 밖으로 나올 경우, 탭바가 안보이는 버그 수정 🟡

### DIFF
--- a/Keychy/Keychy/Presentation/Workshop/Making/Shared/Views/KeyringCustomizingView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Shared/Views/KeyringCustomizingView.swift
@@ -164,6 +164,7 @@ struct KeyringCustomizingView<VM: KeyringViewModelProtocol>: View {
             Button("취소", role: .cancel) { }
             Button("확인", role: .destructive) {
                 viewModel.resetAll()
+                TabBarManager.show()
                 router.reset()
             }
         } message: {

--- a/Keychy/Keychy/Presentation/Workshop/Making/Templates/ClearSketch/Views/ClearSketchDrawingView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Templates/ClearSketch/Views/ClearSketchDrawingView.swift
@@ -87,6 +87,7 @@ struct ClearSketchDrawingView: View {
             Button("취소", role: .cancel) { }
             Button("확인", role: .destructive) {
                 viewModel.resetAll()
+                TabBarManager.show()
                 router.reset()
             }
         } message: {

--- a/Keychy/Keychy/Presentation/Workshop/Making/Templates/Pixel/Views/PixelDrawView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Templates/Pixel/Views/PixelDrawView.swift
@@ -78,6 +78,7 @@ struct PixelDrawView: View {
             Button("취소", role: .cancel) { }
             Button("확인", role: .destructive) {
                 viewModel.resetAll()
+                TabBarManager.show()
                 router.reset()
             }
         } message: {


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용

### 키링 제작 단계 중간에 취소해서 나올 경우, 탭바가 show()처리 되지 않던 문제

> 해결법이 명확했던 이슈입니다.
각 만들기 단계의 back버튼에 탭바 show() 로직을 삽입하고 점검.


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
<img width="250" alt="제작 중 back -  탭바 안보임" src="https://github.com/user-attachments/assets/dc923af1-0c37-4fdc-a1c5-b1fd5d7b1fc1" />

> 제작 중간에 나왔을 때, 탭바가 보이지 않던 모습

**현재는 완벽히 수정했고, 모든 템플릿 전부 로직 테스트 완료했습니다!**


## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #6 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
