### PR TITLE
style: [에셋] - 숏로딩 gif 크기 및 케이스 수정

### DIFF
--- a/Keychy/Keychy/Core/Components/Alerts/LoadingAlert.swift
+++ b/Keychy/Keychy/Core/Components/Alerts/LoadingAlert.swift
@@ -15,13 +15,14 @@ import SwiftUI
 import Lottie
 
 enum LoadingType {
-    case short
+    case short30
+    case short40
     case longWithKeychy
     case longWithPresent
 
     var lottieFileName: String {
         switch self {
-        case .short: return "shotLoading"
+        case .short30, .short40: return "shotLoading"
         case .longWithKeychy: return "longLoadingKeychy"
         case .longWithPresent: return "longLoadingPresent"
         }
@@ -29,7 +30,8 @@ enum LoadingType {
 
     var frameSize: CGFloat {
         switch self {
-        case .short: return 48
+        case .short30: return 30
+        case .short40: return 40
         case .longWithKeychy: return 122
         case .longWithPresent: return 122
         }
@@ -51,7 +53,7 @@ struct LoadingAlert: View {
             )
             .frame(width: type.frameSize, height: type.frameSize)
 
-            if type != .short, let message = message {
+            if type != .short30 && type != .short40, let message = message {
                 Text(message)
                     .typography(.suit17SB)
                     .textOutline(color: .white100, width: 3)

--- a/Keychy/Keychy/Core/Components/View/Items/ItemDetailImage.swift
+++ b/Keychy/Keychy/Core/Components/View/Items/ItemDetailImage.swift
@@ -24,7 +24,7 @@ struct ItemDetailImage: View {
 
             // 로딩 중앙 배치
             if isLoading {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
                     .onAppear {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             isLoading = false
@@ -173,8 +173,7 @@ struct SimpleAnimatedImage: View {
                 if isLoading {
                     Color.gray50
                         .overlay {
-                            LoadingAlert(type: .short, message: nil)
-                                .scaleEffect(0.5)
+                            LoadingAlert(type: .short40, message: nil)
                         }
                 }
             }

--- a/Keychy/Keychy/Presentation/Bundle/Views/BundleCreateView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/BundleCreateView.swift
@@ -445,8 +445,7 @@ extension BundleCreateView {
         } label: {
             HStack(spacing: 5) {
                 if isPurchasing {
-                    LoadingAlert(type: .short, message: nil)
-                        .scaleEffect(0.8)
+                    LoadingAlert(type: .short40, message: nil)
                 } else {
                     Image(.purchaseSheet)
                 }

--- a/Keychy/Keychy/Presentation/Bundle/Views/BundleEditView+Purchase.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/BundleEditView+Purchase.swift
@@ -94,8 +94,7 @@ extension BundleEditView {
         } label: {
             HStack(spacing: 5) {
                 if isPurchasing {
-                    LoadingAlert(type: .short, message: nil)
-                        .scaleEffect(0.8)
+                    LoadingAlert(type: .short40, message: nil)
                 } else {
                     Image(.purchaseSheet)
                 }

--- a/Keychy/Keychy/Presentation/Bundle/Views/BundleEditView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/BundleEditView+SelectSheet.swift
@@ -80,7 +80,7 @@ extension BundleEditView {
                     
                     if isKeyringSheetLoading {
                         VStack {
-                            LoadingAlert(type: .short, message: nil)
+                            LoadingAlert(type: .short40, message: nil)
                                 .padding(.vertical, 24)
                             Text("키링을 불러오고 있어요")
                                 .typography(.suit15R)

--- a/Keychy/Keychy/Presentation/Bundle/Views/Component/BackgroundSelectableCell.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Component/BackgroundSelectableCell.swift
@@ -23,8 +23,7 @@ struct BackgroundSelectableCell: View {
                             .scaledToFill()
                             .clipped()
                     } else if state.isLoading {
-                        LoadingAlert(type: .short, message: nil)
-                            .scaleEffect(0.5)
+                        LoadingAlert(type: .short30, message: nil)
                     }
                 }
                 .frame(width: threeSquareGridCellSize, height: threeSquareGridCellSize)

--- a/Keychy/Keychy/Presentation/Bundle/Views/Component/CarabinerSelectableCell.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Component/CarabinerSelectableCell.swift
@@ -23,8 +23,7 @@ struct CarabinerSelectableCell: View {
                             .scaledToFit()
                             .clipped()
                     } else if state.isLoading {
-                        LoadingAlert(type: .short, message: nil)
-                            .scaleEffect(0.5)
+                        LoadingAlert(type: .short30, message: nil)
                     } else {
                         Color.clear
                             .aspectRatio(1, contentMode: .fit)

--- a/Keychy/Keychy/Presentation/Bundle/Views/Component/KeyringBundleItem.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Component/KeyringBundleItem.swift
@@ -65,7 +65,7 @@ extension KeyringBundleItem {
         return Group {
             if isCapturing {
                 // 캡처 중 ProgressView
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             } else if let cachedImage = cachedImage {
                 cachedImage
                     .resizable()

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Alerts.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Alerts.swift
@@ -126,7 +126,7 @@ extension CollectionKeyringDetailView {
             }
             
             if showCopyingAlert {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
                     .zIndex(101)
             }
             

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView.swift
@@ -104,7 +104,7 @@ struct CollectionKeyringDetailView: View {
                     Color.black20
                         .ignoresSafeArea()
                         
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                         .zIndex(200)
                 }
                 

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringPackageView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringPackageView.swift
@@ -44,7 +44,7 @@ struct CollectionKeyringPackageView: View {
                     Color.black20
                         .ignoresSafeArea()
                     
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                         .zIndex(101)
                 }
                 

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/KeyringEditView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/KeyringEditView.swift
@@ -202,8 +202,7 @@ extension KeyringEditView {
                     Color.black20
                         .overlay {
                             VStack(spacing: 8) {
-                                LoadingAlert(type: .short, message: nil)
-                                    .scaleEffect(0.4)
+                                LoadingAlert(type: .short40, message: nil)
                             }
                         }
                 }

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/PackagedKeyringView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/PackagedKeyringView.swift
@@ -204,9 +204,8 @@ extension PackagedKeyringView {
                      )
              } else {
                  // 이미지 로딩 중
-                 LoadingAlert(type: .short, message: nil)
+                 LoadingAlert(type: .short40, message: nil)
                      .frame(width: 195, height: 300)
-                     .scaleEffect(0.6)
              }
         }
     }
@@ -299,9 +298,8 @@ extension PackagedKeyringView {
                     .scaledToFit()
                     .frame(width: 205, height: 205)
             } else {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
                     .frame(width: 205, height: 205)
-                    .scaleEffect(0.6)
             }
         }
         .offset(x: -3, y: -24)

--- a/Keychy/Keychy/Presentation/Collection/Views/Main/CollectionCellView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Main/CollectionCellView.swift
@@ -23,8 +23,7 @@ struct CollectionCellView: View {
             if isLoading && cachedImage == nil {
                 Color.gray50
                     .overlay {
-                        LoadingAlert(type: .short, message: nil)
-                            .scaleEffect(0.7)
+                        LoadingAlert(type: .short40, message: nil)
                     }
             }
 

--- a/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringCollectView+Alerts.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringCollectView+Alerts.swift
@@ -31,7 +31,7 @@ extension KeyringCollectView {
     }
     
     private func loadingOverlay(geometry: GeometryProxy) -> some View {
-        LoadingAlert(type: .short, message: nil)
+        LoadingAlert(type: .short40, message: nil)
             .position(
                 x: geometry.size.width / 2,
                 y: geometry.size.height / 2

--- a/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringCollectView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringCollectView.swift
@@ -58,7 +58,7 @@ struct KeyringCollectView: View {
     private func contentView(heightRatio: CGFloat, isSmallScreen: Bool) -> some View {
         VStack(spacing: 0) {
             if viewModel.isLoading {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 
             } else if let keyring = viewModel.keyring {

--- a/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringReceiveView+Alerts.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringReceiveView+Alerts.swift
@@ -35,7 +35,7 @@ extension KeyringReceiveView {
     }
     
     private func loadingOverlay(geometry: GeometryProxy) -> some View {
-        LoadingAlert(type: .short, message: nil)
+        LoadingAlert(type: .short40, message: nil)
             .position(
                 x: geometry.size.width / 2,
                 y: geometry.size.height / 2

--- a/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringReceiveView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Package/KeyringReceiveView.swift
@@ -58,7 +58,7 @@ struct KeyringReceiveView: View {
     private func contentView(heightRatio: CGFloat, isSmallScreen: Bool) -> some View {
         VStack(spacing: 0) {
             if viewModel.isLoading {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 
             } else if viewModel.isAlreadyReceived {

--- a/Keychy/Keychy/Presentation/Festival/Views/FestivalKeyringDetailView+Alerts.swift
+++ b/Keychy/Keychy/Presentation/Festival/Views/FestivalKeyringDetailView+Alerts.swift
@@ -46,7 +46,7 @@ extension FestivalKeyringDetailView {
             }
             
             if showCopyingAlert {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
                     .zIndex(101)
             }
             

--- a/Keychy/Keychy/Presentation/Festival/Views/FestivalKeyringDetailView.swift
+++ b/Keychy/Keychy/Presentation/Festival/Views/FestivalKeyringDetailView.swift
@@ -66,7 +66,7 @@ struct FestivalKeyringDetailView: View {
                     Color.black20
                         .ignoresSafeArea()
                         
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                         .zIndex(200)
                 }
                 

--- a/Keychy/Keychy/Presentation/Festival/Views/Showcase25Board/Showcase25BoardView+Grid.swift
+++ b/Keychy/Keychy/Presentation/Festival/Views/Showcase25Board/Showcase25BoardView+Grid.swift
@@ -27,8 +27,7 @@ extension Showcase25BoardView {
                 // 다른 사람이 수정 중인 경우
                 let maskedName = viewModel.maskedNickname(editingKeyring.editingUserNickname)
                 ZStack {
-                    LoadingAlert(type: .short, message: nil)
-                        .scaleEffect(0.5)
+                    LoadingAlert(type: .short30, message: nil)
                     VStack {
                         Spacer()
                         Text("\(maskedName)님\n수정중")
@@ -103,8 +102,7 @@ extension Showcase25BoardView {
                 Image(systemName: "photo")
                     .foregroundStyle(.gray300)
             } else {
-                LoadingAlert(type: .short, message: nil)
-                    .scaleEffect(0.5)
+                LoadingAlert(type: .short30, message: nil)
             }
         }
 

--- a/Keychy/Keychy/Presentation/Home/Views/Alarm/NotificationGiftView.swift
+++ b/Keychy/Keychy/Presentation/Home/Views/Alarm/NotificationGiftView.swift
@@ -24,7 +24,7 @@ struct NotificationGiftView: View {
             if viewModel.hasNetworkError {
                 networkErrorView
             } else if viewModel.isLoading || viewModel.isCapturing {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             } else if let error = viewModel.loadError {
                 VStack {
                     Text("선물 정보를 불러올 수 없습니다")

--- a/Keychy/Keychy/Presentation/Home/Views/MyPage/ChangeNameView.swift
+++ b/Keychy/Keychy/Presentation/Home/Views/MyPage/ChangeNameView.swift
@@ -147,7 +147,7 @@ extension ChangeNameView {
         Group {
             // 업데이트 중 로딩
             if viewModel.isUpdating {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             }
 
             // 성공 Alert

--- a/Keychy/Keychy/Presentation/Home/Views/MyPage/MyPageView.swift
+++ b/Keychy/Keychy/Presentation/Home/Views/MyPage/MyPageView.swift
@@ -304,7 +304,7 @@ extension MyPageView {
     private var alerts: some View {
         Group {
             if viewModel.showLoadingAlert {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             }
         }
     }

--- a/Keychy/Keychy/Presentation/Intro/Views/ProfileSetupCompleteView.swift
+++ b/Keychy/Keychy/Presentation/Intro/Views/ProfileSetupCompleteView.swift
@@ -37,7 +37,7 @@ struct ProfileSetupCompleteView: View {
             .blur(radius: isSaving ? 15 : 0)
 
             if isSaving {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             }
         }
         .background(.white100)

--- a/Keychy/Keychy/Presentation/Workshop/Coin/CoinChargeView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Coin/CoinChargeView.swift
@@ -98,7 +98,7 @@ struct CoinChargeView<Route: Hashable>: View {
 
             // 코인 구매 로딩
             if isCoinPurchasing {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             }
         }
         .task {

--- a/Keychy/Keychy/Presentation/Workshop/Making/Shared/Components/PreviewGuiding.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Shared/Components/PreviewGuiding.swift
@@ -106,7 +106,7 @@ extension PreviewGuiding {
             // 로딩 중앙 배치
             LazyImage(url: URL(string: guidingImageURL)) { state in
                 if state.isLoading {
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                 }
             }
         }

--- a/Keychy/Keychy/Presentation/Workshop/Making/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Shared/Components/TemplatePreviewComponents.swift
@@ -120,7 +120,7 @@ struct TemplatePreviewBody: View {
 
                 // 구매 중 로딩
                 if showPurchasingLoading {
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                 }
 
                 // 구매 성공 알림
@@ -187,7 +187,7 @@ extension TemplatePreviewBody {
                     .scaledToFit()
                     .frame(width: 386, height: 386)
             } else {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             }
         }
         .frame(maxHeight: 500)
@@ -226,7 +226,7 @@ extension TemplatePreviewBody {
                     }
                 )
             } else {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             }
         }
     }

--- a/Keychy/Keychy/Presentation/Workshop/Making/Shared/Views/KeyringCustomizingView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Shared/Views/KeyringCustomizingView.swift
@@ -88,13 +88,13 @@ struct KeyringCustomizingView<VM: KeyringViewModelProtocol>: View {
                 
                 // MARK: - 구매 중 로딩
                 if showPurchaseProgress {
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                         .zIndex(101)
                 }
 
                 // MARK: - 합성 중 로딩
                 if viewModel.isComposing {
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                         .zIndex(101)
                 }
 

--- a/Keychy/Keychy/Presentation/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoCropView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Templates/AcrylicPhoto/Views/AcrylicPhotoCropView.swift
@@ -61,7 +61,7 @@ struct AcrylicPhotoCropView: View {
 
             // 로딩 인디케이터
             if isImageLoading {
-                LoadingAlert(type: .short, message: nil)
+                LoadingAlert(type: .short40, message: nil)
             }
             
             customNavigationBar

--- a/Keychy/Keychy/Presentation/Workshop/Making/Templates/ClearSketch/Views/ClearSketchCropView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Templates/ClearSketch/Views/ClearSketchCropView.swift
@@ -27,7 +27,7 @@ struct ClearSketchCropView: View {
                     if let bodyImage = viewModel.bodyImage {
                         cropCanvasView(image: bodyImage, geometry: geometry)
                     } else {
-                        LoadingAlert(type: .short, message: nil)
+                        LoadingAlert(type: .short40, message: nil)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Keychy/Keychy/Presentation/Workshop/Making/Templates/Polaroid/Views/FramePreviewView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Templates/Polaroid/Views/FramePreviewView.swift
@@ -63,7 +63,7 @@ struct FramePreviewView: View {
 
                 // 로딩 중일 때
                 if !isFrameLoaded {
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                 }
             }
         }
@@ -227,7 +227,7 @@ struct FramePreviewView: View {
                 // 프레임 크기 계산
                 LazyImage(url: URL(string: frame.frameURL)) { state in
                     if state.isLoading {
-                        LoadingAlert(type: .short, message: nil)
+                        LoadingAlert(type: .short40, message: nil)
                             .frame(height: targetFrameHeight)
                     } else if let image = state.image {
                         let frameAspect = (state.imageContainer?.image.size.width ?? 1) / (state.imageContainer?.image.size.height ?? 1)

--- a/Keychy/Keychy/Presentation/Workshop/Making/Templates/SpeechBubble/Views/SpeechBubbleFramePreviewView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Making/Templates/SpeechBubble/Views/SpeechBubbleFramePreviewView.swift
@@ -48,7 +48,7 @@ struct SpeechBubbleFramePreviewView: View {
 
                 // 로딩 중일 때
                 if !isFrameLoaded {
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                 }
             }
         }

--- a/Keychy/Keychy/Presentation/Workshop/WorkshopComponents.swift
+++ b/Keychy/Keychy/Presentation/Workshop/WorkshopComponents.swift
@@ -153,8 +153,7 @@ struct WorkshopItemView<Item: WorkshopItem>: View {
                             .frame(width: twoGridCellWidth, height: itemHeight)
                             .clipped()
                     } else {
-                        LoadingAlert(type: .short, message: nil)
-                            .scaleEffect(0.5)
+                        LoadingAlert(type: .short40, message: nil)
                             .task {
                                 await ensureParticleReady(particle)
                             }

--- a/Keychy/Keychy/Presentation/Workshop/WorkshopPreview.swift
+++ b/Keychy/Keychy/Presentation/Workshop/WorkshopPreview.swift
@@ -130,7 +130,7 @@ struct WorkshopPreview: View {
 
                 // 구매 중 로딩
                 if showPurchasingLoading {
-                    LoadingAlert(type: .short, message: nil)
+                    LoadingAlert(type: .short40, message: nil)
                 }
 
                 // 구매 성공 알림
@@ -208,8 +208,7 @@ extension WorkshopPreview {
                         .aspectRatio(1, contentMode: .fit)
                         .cornerRadius(20)
                 } else {
-                    LoadingAlert(type: .short, message: nil)
-                        .scaleEffect(0.5)
+                    LoadingAlert(type: .short40, message: nil)
                     .task {
                         await ensureParticleReady(particle)
                     }


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용

###  기존 LoadingAlert의 .short 타입을 .short30과 .short40으로 분리하여 일관된 사이즈 시스템을 적용했습니다.

  **- short30: 30pt (작은 셀/썸네일용)**
  **- short40: 40pt (일반 로딩용)**

  기존에 scaleEffect()로 임의 조정하던 방식을 제거하고, 명시적인 타입으로 관리합니다.
  > 실제로 스케일이펙트로 마구잡이로 각 뷰에서 사용되어지고 있었다.
  좋은 이슈인 것 같습니다.

#### 수정된 파일  
- `LoadingAlert.swift`: LoadingType enum 수정
- **42개 파일(!!!)에서 LoadingAlert 타입 변경 및 scaleEffect 제거**

## 로딩 사용처 전체 목록

### 🏠 홈
  | 화면 | 위치 | 설명 |
  |------|------|------|
  | 마이페이지 | 전체 | 데이터 로딩 |
  | 이름 변경 | 전체 | 업데이트 중 로딩 |
  | 알림 선물 | 전체 | 선물 정보 로딩 |

  ### 🎪 페스티벌
  | 화면 | 위치 | 설명 |
  |------|------|------|
  | 페스티벌 쇼케이스 | 그리드 셀 | 다른 사람이 수정 중일 때 표시 |
  | 페스티벌 쇼케이스 | 그리드 셀 | 키링 이미지 로딩 |
  | 페스티벌 키링 상세 | 전체 | 키링 정보 로딩 |
  | 페스티벌 키링 상세 | 알럿 | 키링 복사 중 |

  ### 📦 보관함
  | 화면 | 위치 | 설명 |
  |------|------|------|
  | 보관함 메인 | 키링 셀 | 키링 이미지 로딩 |
  | 키링 상세 | 전체 | 키링 정보 로딩 |
  | 키링 상세 | 알럿 | 키링 복사 중 |
  | 키링 수정 | 전체 | 수정 중 로딩 |
  | 키링 포장 | 전체 | 포장 처리 중 |
  | 포장된 키링 | 프리뷰 영역 | 이미지 로딩 |
  | 키링 받기 | 전체 | 키링 정보 로딩 |
  | 키링 받기 | 알럿 | 받기 처리 중 |
  | 키링 수집 | 전체 | 키링 정보 로딩 |
  | 키링 수집 | 알럿 | 수집 처리 중 |

  ### 🎨 공방
  | 화면 | 위치 | 설명 |
  |------|------|------|
  | 공방 아이템 목록 | 썸네일 | 파티클 로딩 |
  | 공방 아이템 상세 | 프리뷰 | 구매 중 로딩 |
  | 공방 아이템 상세 | 프리뷰 | 파티클 로딩 |
  | 아이템 상세 이미지 | 전체 | 이미지 로딩 |
  | 코인 충전 | 전체 | 구매 처리 중 |

  ### ✨ 키링 제작
  | 화면 | 위치 | 설명 |
  |------|------|------|
  | 템플릿 프리뷰 | 전체 | 구매 중 로딩 |
  | 템플릿 프리뷰 | 프리뷰 영역 | 템플릿 이미지 로딩 |
  | 프리뷰 가이딩 | 시트 | 가이딩 이미지 로딩 |
  | 키링 커스터마이징 | 전체 | 구매 중 / 합성 중 로딩 |
  | 폴라로이드 프레임 선택 | 전체 | 프레임 로딩 |
  | 말풍선 프레임 선택 | 전체 | 프레임 로딩 |
  | 아크릴포토 크롭 | 전체 | 이미지 로딩 |
  | 스케치 크롭 | 전체 | 이미지 로딩 |

  ### 🎁 뭉치
  | 화면 | 위치 | 설명 |
  |------|------|------|
  | 뭉치 만들기 | 구매 버튼 | 구매 처리 중 |
  | 뭉치 만들기 | 배경 선택 시트 | 배경 썸네일 로딩 |
  | 뭉치 만들기 | 카라비너 선택 시트 | 카라비너 썸네일 로딩 |
  | 뭉치 수정 | 구매 버튼 | 구매 처리 중 |
  | 뭉치 수정 | 키링 선택 시트 | 키링 목록 로딩 |
  | 뭉치 아이템 | 셀 | 캡처 중 로딩 |

  ### 👋 온보딩
  | 화면 | 위치 | 설명 |
  |------|------|------|
  | 프로필 설정 완료 | 전체 | 저장 중 로딩 |

> 현재는 가볍게 기존에 0.5 크기 였던 애들은 30 나머지는 40으로 통일시킴.
피그마 참고.

> 무진장 많은데, 알잘딱해서 30/40 적용하면 될듯

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #8 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료 
> 테스트를 하긴 했는데, 
앞으로 뷰가 바뀌는 곳이 많아서 
앞으로 뷰 개발할 때 정밀한 테스트가 다시 필요함! 
(큰 문제는 없어보임)

- [x] Self-review 완료
