### PR TITLE
feat: [키링 상세뷰] 복사 메뉴 조건부 비활성화 및 도움말 추가

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3828F5472EC4CCDC00F1B040 /* CollectionView+NormalMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3828F5462EC4CCDC00F1B040 /* CollectionView+NormalMode.swift */; };
 		3828F5492EC4CCE400F1B040 /* CollectionView+SearchMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3828F5482EC4CCE400F1B040 /* CollectionView+SearchMode.swift */; };
 		3828F54B2EC4D0C500F1B040 /* CollectionView+Handlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3828F54A2EC4D0C500F1B040 /* CollectionView+Handlers.swift */; };
+		38489EBD2F290BD000E41FAE /* CopyTooltipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38489EBC2F290BD000E41FAE /* CopyTooltipView.swift */; };
 		385425BE2EB2989400A06C02 /* CollectionCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385425BD2EB2989400A06C02 /* CollectionCellView.swift */; };
 		385425C02EB2AE7800A06C02 /* CollectionViewModel+Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385425BF2EB2AE7800A06C02 /* CollectionViewModel+Sort.swift */; };
 		385425C32EB2C35E00A06C02 /* WidgetSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385425C22EB2C35E00A06C02 /* WidgetSettingView.swift */; };
@@ -475,6 +476,7 @@
 		3828F5462EC4CCDC00F1B040 /* CollectionView+NormalMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionView+NormalMode.swift"; sourceTree = "<group>"; };
 		3828F5482EC4CCE400F1B040 /* CollectionView+SearchMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionView+SearchMode.swift"; sourceTree = "<group>"; };
 		3828F54A2EC4D0C500F1B040 /* CollectionView+Handlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionView+Handlers.swift"; sourceTree = "<group>"; };
+		38489EBC2F290BD000E41FAE /* CopyTooltipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyTooltipView.swift; sourceTree = "<group>"; };
 		385425BD2EB2989400A06C02 /* CollectionCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionCellView.swift; sourceTree = "<group>"; };
 		385425BF2EB2AE7800A06C02 /* CollectionViewModel+Sort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionViewModel+Sort.swift"; sourceTree = "<group>"; };
 		385425C22EB2C35E00A06C02 /* WidgetSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSettingView.swift; sourceTree = "<group>"; };
@@ -960,6 +962,7 @@
 				38A22A9C2EC27AC400B4C7C5 /* PackagedKeyringView+SaveImage.swift */,
 				3822DDC12EBBC712003125BE /* KeyringEditView.swift */,
 				3822DDBF2EBB2353003125BE /* KeyringMenu.swift */,
+				38489EBC2F290BD000E41FAE /* CopyTooltipView.swift */,
 			);
 			path = Detail;
 			sourceTree = "<group>";
@@ -2544,6 +2547,7 @@
 				4C4733A62F1FA388005D2376 /* KeyringCompleteView+VideoGen.swift in Sources */,
 				4C4733A72F1FA388005D2376 /* KeyringCompleteView.swift in Sources */,
 				4C4733A82F1FA388005D2376 /* AcrylicPhotoVM+ImageLoad.swift in Sources */,
+				38489EBD2F290BD000E41FAE /* CopyTooltipView.swift in Sources */,
 				4C4733A92F1FA388005D2376 /* NeonSignPreview.swift in Sources */,
 				4C4733AA2F1FA388005D2376 /* SpeechBubbleFrameSelectorView.swift in Sources */,
 				4C4733AB2F1FA388005D2376 /* KeyringViewModelProtocol+Reset.swift in Sources */,

--- a/Keychy/Keychy/Core/DesignSystem/Typography/Typography.swift
+++ b/Keychy/Keychy/Core/DesignSystem/Typography/Typography.swift
@@ -74,6 +74,7 @@ struct Typography {
     static let nanum18EB = Typography(font: .custom(.nanumExtraBold, size: 18), lineSpacing: 0)
     static let nanum17EB = Typography(font: .custom(.nanumExtraBold, size: 17), lineSpacing: 0)
     static let nanum16EB = Typography(font: .custom(.nanumExtraBold, size: 16), lineSpacing: 0)
+    static let nanum12EB = Typography(font: .custom(.nanumExtraBold, size: 12), lineSpacing: 0)
 
     static let nanum15EB25 = Typography(font: .custom(.nanumExtraBold, size: 15), lineSpacing: 10)
     static let nanum15B25 = Typography(font: .custom(.nanumBold, size: 15), lineSpacing: 10)

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Menu.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Menu.swift
@@ -39,6 +39,9 @@ extension CollectionKeyringDetailView {
                 },
                 onDelete: {
                     handleMenuDelete()
+                },
+                onWidget: {
+                    goToWidgetOnboarding()
                 }
             )
             .zIndex(50)
@@ -81,6 +84,16 @@ extension CollectionKeyringDetailView {
         
         withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
             showDeleteAlert = true
+        }
+    }
+    
+    // MARK: - 위젯 설정 화면으로 이동
+    private func goToWidgetOnboarding() {
+        isSheetPresented = false
+        showMenu = false
+        
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+            router.push(.widgetSettingView)
         }
     }
 

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CopyTooltipView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CopyTooltipView.swift
@@ -1,0 +1,59 @@
+//
+//  CopyTooltipView.swift
+//  Keychy
+//
+//  Created by Jini on 1/28/26.
+//
+
+import SwiftUI
+
+// 툴팁 말풍선 View
+struct CopyTooltipView: View {
+    
+    @State private var isAppearing = false
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // 삼각형 (위쪽 꼬리)
+            Triangle()
+                .fill(Color.white100)
+                .frame(width: 36, height: 15)
+                .offset(x: 82, y: 2)
+            
+            // 말풍선 내용
+            Text("내가 만든 키링만 복사할 수 있어요.")
+                .typography(.suit15SB25)
+                .foregroundColor(.black100)
+                .padding(.horizontal, 15)
+                .padding(.vertical, 13)
+                .background(.white100)
+                .cornerRadius(13)
+        }
+        .frame(width: 235, height: 45)
+        .compositingGroup()
+        .shadow(color: .black.opacity(0.1), radius: 12, x: 0, y: 3)
+        .scaleEffect(isAppearing ? 1.0 : 0.8, anchor: .top)
+        .opacity(isAppearing ? 1.0 : 0.0)
+        .onAppear {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                isAppearing = true
+            }
+        }
+    }
+}
+
+// 삼각형 Shape
+struct Triangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+#Preview {
+    CopyTooltipView()
+}

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/KeyringMenu.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/KeyringMenu.swift
@@ -13,11 +13,13 @@ struct KeyringMenu: View {
     let onEdit: () -> Void
     let onCopy: () -> Void
     let onDelete: () -> Void
+    let onWidget: () -> Void
     
     private let menuWidth: CGFloat = 165
-    private var menuHeight: CGFloat {
-        isMyKeyring ? 170 : 115  // 복사 버튼 있으면 170, 없으면 115
-    }
+//    private var menuHeight: CGFloat {
+//        isMyKeyring ? 170 : 115  // 복사 버튼 있으면 170, 없으면 115
+//    }
+    private let menuHeight: CGFloat = 218
     
     @State private var isAppearing = false
     
@@ -76,6 +78,31 @@ struct KeyringMenu: View {
                             Text("삭제")
                                 .typography(.suit16M)
                                 .foregroundColor(.pink)
+                            
+                            Spacer()
+                        }
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 10)
+                        .contentShape(Rectangle())
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    
+                    Rectangle()
+                        .fill(Color.gray100)
+                        .padding(.horizontal, 10)
+                        .frame(height: 1)
+                    
+                    // 위젯 버튼
+                    Button(action: onWidget) {
+                        HStack(spacing: 8) {
+                            Image(.widget)
+                                .resizable()
+                                .frame(width: 25, height: 25)
+                                .foregroundStyle(.gray600)
+                            
+                            Text("위젯 설정")
+                                .typography(.suit16M)
+                                .foregroundColor(.gray600)
                             
                             Spacer()
                         }

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/KeyringMenu.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/KeyringMenu.swift
@@ -188,13 +188,6 @@ struct KeyringMenu: View {
         .onPreferenceChange(QuestionButtonPreferenceKey.self) { frame in
             questionButtonFrame = frame
         }
-        .onTapGesture {
-            if showCopyTooltip {
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                    showCopyTooltip = false
-                }
-            }
-        }
     }
 }
 

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/KeyringMenu.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/KeyringMenu.swift
@@ -15,113 +15,32 @@ struct KeyringMenu: View {
     let onDelete: () -> Void
     let onWidget: () -> Void
     
-    private let menuWidth: CGFloat = 165
-//    private var menuHeight: CGFloat {
-//        isMyKeyring ? 170 : 115  // 복사 버튼 있으면 170, 없으면 115
-//    }
+    private let menuWidth: CGFloat = 200
     private let menuHeight: CGFloat = 218
     
     @State private var isAppearing = false
+    @State private var showCopyTooltip = false
+    @State private var questionButtonFrame: CGRect = .zero
     
     var body: some View {
         GeometryReader { geometry in
             ZStack {
                 // 메뉴
-                VStack(alignment: .leading, spacing: 5) {
-                    // 편집 버튼
-                    Button(action: onEdit) {
-                        HStack(spacing: 8) {
-                            Image(.pencil)
-                                .resizable()
-                                .frame(width: 25, height: 25)
-                            
-                            Text("정보 수정")
-                                .typography(.suit16M)
-                                .foregroundColor(.gray600)
-                            
-                            Spacer()
-                        }
-                        .padding(.vertical, 10)
-                        .padding(.horizontal, 10)
-                        .contentShape(Rectangle())
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    
-                    if isMyKeyring {
-                        // 복사 버튼
-                        Button(action: onCopy) {
-                            HStack(spacing: 8) {
-                                Image(.copy)
-                                    .resizable()
-                                    .frame(width: 25, height: 25)
-                                
-                                Text("복사")
-                                    .typography(.suit16M)
-                                    .foregroundColor(.gray600)
-                                
-                                Spacer()
-                            }
-                            .padding(.vertical, 10)
-                            .padding(.horizontal, 10)
-                            .contentShape(Rectangle())
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    
-                    // 삭제 버튼
-                    Button(action: onDelete) {
-                        HStack(spacing: 8) {
-                            Image(.trash)
-                                .resizable()
-                                .frame(width: 25, height: 25)
-                            
-                            Text("삭제")
-                                .typography(.suit16M)
-                                .foregroundColor(.pink)
-                            
-                            Spacer()
-                        }
-                        .padding(.vertical, 10)
-                        .padding(.horizontal, 10)
-                        .contentShape(Rectangle())
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    
-                    Rectangle()
-                        .fill(Color.gray100)
-                        .padding(.horizontal, 10)
-                        .frame(height: 1)
-                    
-                    // 위젯 버튼
-                    Button(action: onWidget) {
-                        HStack(spacing: 8) {
-                            Image(.widget)
-                                .resizable()
-                                .frame(width: 25, height: 25)
-                                .foregroundStyle(.gray600)
-                            
-                            Text("위젯 설정")
-                                .typography(.suit16M)
-                                .foregroundColor(.gray600)
-                            
-                            Spacer()
-                        }
-                        .padding(.vertical, 10)
-                        .padding(.horizontal, 10)
-                        .contentShape(Rectangle())
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                menuContent
+                    .position(
+                        x: geometry.size.width - menuWidth / 2 - 16,
+                        y: position.maxY + 8 + menuHeight / 2
+                    )
+                
+                // 툴팁 말풍선
+                if showCopyTooltip {
+                    CopyTooltipView()
+                        .position(
+                            x: geometry.size.width - 125,
+                            y: questionButtonFrame.maxY + 32
+                        )
+                        .zIndex(1000)
                 }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 20)
-                .frame(width: menuWidth, height: menuHeight)
-                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 34))
-                .scaleEffect(isAppearing ? 1.0 : 0.8, anchor: .topTrailing)
-                .opacity(isAppearing ? 1.0 : 0.0)
-                .position(
-                    x: geometry.size.width - menuWidth / 2 - 16,
-                    y: position.maxY + 8 + menuHeight / 2
-                )
             }
         }
         .onAppear {
@@ -129,5 +48,161 @@ struct KeyringMenu: View {
                 isAppearing = true
             }
         }
+        // 툴팁 외부 클릭 시 닫기
+        .onTapGesture {
+            if showCopyTooltip {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    showCopyTooltip = false
+                }
+            }
+        }
+    }
+    
+    private var menuContent: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            // 편집 버튼
+            Button(action: onEdit) {
+                HStack(spacing: 8) {
+                    Image(.pencil)
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(width: 25, height: 25)
+                        .foregroundColor(.gray600)
+                    
+                    Text("정보 수정")
+                        .typography(.suit16M)
+                        .foregroundColor(.gray600)
+                    
+                    Spacer()
+                }
+                .padding(.vertical, 10)
+                .padding(.horizontal, 10)
+                .contentShape(Rectangle())
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            // 복사 버튼
+            HStack(spacing: 8) {
+                Image(.copy)
+                    .renderingMode(.template)
+                    .resizable()
+                    .frame(width: 25, height: 25)
+                    .foregroundColor(isMyKeyring ? .gray600 : .gray300)
+                
+                Text("복사")
+                    .typography(.suit16M)
+                    .foregroundColor(isMyKeyring ? .gray600 : .gray300)
+                
+                Spacer()
+                
+                if !isMyKeyring {
+                    Button {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                            showCopyTooltip.toggle()
+                        }
+                    } label: {
+                        ZStack {
+                            Circle()
+                                .fill(Color.gray500)
+                                .frame(width: 15, height: 15)
+                            
+                            Text("?")
+                                .typography(.nanum12EB)
+                                .foregroundColor(.white)
+                        }
+                    }
+                    // 물음표 버튼의 위치 추적
+                    .background(
+                        GeometryReader { geo in
+                            Color.clear
+                                .preference(
+                                    key: QuestionButtonPreferenceKey.self,
+                                    value: geo.frame(in: .global)
+                                )
+                        }
+                    )
+                }
+            }
+            .padding(.vertical, 10)
+            .padding(.horizontal, 10)
+            .contentShape(Rectangle())
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onTapGesture {
+                if isMyKeyring {
+                    onCopy()
+                }
+            }
+            
+            // 삭제 버튼
+            Button(action: onDelete) {
+                HStack(spacing: 8) {
+                    Image(.trash)
+                        .resizable()
+                        .frame(width: 25, height: 25)
+                    
+                    Text("삭제")
+                        .typography(.suit16M)
+                        .foregroundColor(.pink)
+                    
+                    Spacer()
+                }
+                .padding(.vertical, 10)
+                .padding(.horizontal, 10)
+                .contentShape(Rectangle())
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            // 구분선
+            Rectangle()
+                .fill(Color.gray100)
+                .padding(.horizontal, 10)
+                .frame(height: 1)
+            
+            // 위젯 버튼
+            Button(action: onWidget) {
+                HStack(spacing: 8) {
+                    Image(.widget)
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                        .foregroundColor(.gray600)
+                    
+                    Text("위젯 설정")
+                        .typography(.suit16M)
+                        .foregroundColor(.gray600)
+                    
+                    Spacer()
+                }
+                .padding(.vertical, 10)
+                .padding(.horizontal, 10)
+                .contentShape(Rectangle())
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 20)
+        .frame(width: menuWidth, height: menuHeight)
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 34))
+        .scaleEffect(isAppearing ? 1.0 : 0.8, anchor: .topTrailing)
+        .opacity(isAppearing ? 1.0 : 0.0)
+        .onPreferenceChange(QuestionButtonPreferenceKey.self) { frame in
+            questionButtonFrame = frame
+        }
+        .onTapGesture {
+            if showCopyTooltip {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    showCopyTooltip = false
+                }
+            }
+        }
+    }
+}
+
+// 물음표 버튼 위치 추적용 PreferenceKey
+struct QuestionButtonPreferenceKey: PreferenceKey {
+    static var defaultValue: CGRect = .zero
+    
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
     }
 }

--- a/Keychy/Keychy/Presentation/Collection/Views/Main/CollectionView+NormalMode.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Main/CollectionView+NormalMode.swift
@@ -95,15 +95,15 @@ extension CollectionView {
             .padding(.trailing, 10)
             #endif
             
-            CircleGlassButton(imageName: "Widget",
-                              action: {
-                isSearchFieldFocused = false
-                showSearchBar = false
-                
-                router.push(.widgetSettingView)
-            }
-            )
-            .padding(.trailing, 10)
+//            CircleGlassButton(imageName: "Widget",
+//                              action: {
+//                isSearchFieldFocused = false
+//                showSearchBar = false
+//                
+//                router.push(.widgetSettingView)
+//            }
+//            )
+//            .padding(.trailing, 10)
 
             CircleGlassButton(imageName: "BundleIcon",
                               action: {


### PR DESCRIPTION
## 🎯 PR 내용
### 1. 위젯 설정 위치 변경

기존 : 보관함 밖에 나와있었음
변경 후 : 키링 상세뷰의 메뉴 맨 아래로 이동함

> 기존 위치에 있던 버튼 삭제
<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/b40f98b1-c387-428f-9194-d85963974b54" />

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/a0ec5aba-6bfc-4794-8875-1fe35e8729cd" />


### 2. 복사 메뉴 조건에 따른 비활성화 스타일 추가

**복사 가능 조건 : 해당 키링의 authorId가 유저 id와 일치할 경우**
```
복사 가능할 때 -> 기존처럼 복사 메뉴 활성화된 채 보임
복사 불가능할 때 -> 기존에는 메뉴 자체가 없었지만 지금은 비활성화된채로 보여주면서 우측에 ? 도움말 버튼 표시
```

<img width="201" height="437" alt="image" src="https://github.com/user-attachments/assets/ddc9f07e-5f4f-4333-969a-9127ef5ef017" />


### 3. 복사 메뉴 비활성 시 도움말 추가

복사 메뉴가 비활성화되어있을 때 도움말(?) 버튼을 누르면 아래로 향하는 말풍선 모양의 툴팁(팝오버)가 나타남.

<img width="300" height="86" alt="image" src="https://github.com/user-attachments/assets/729c886e-34ac-40bb-a575-c68262ca0faa" />

> 디자인을 조금 더 둥글게 손보고 싶지만 다른 것들 기능 구현이 급하기 때문에 조금 미뤄두겠음... 차차 발전시키는 것으로....

### 4. 포장 팝업 관련

해당 부분은 아까 논의된 바에 따라 수정하지 않는 것으로 결정되어 그대로 유지함.


## 📱 스크린샷 (UI 변경 시)

> 화질 죄송...
> 이전엔 잘만 올라가더니 10MB 이내만 업로드 가능하다고 하네요...

https://github.com/user-attachments/assets/043d7b8f-010b-484f-be0c-9f3734c763d2


## 🔗 관련 이슈
#22 

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
