### PR TITLE
feat, style: [키링 만들기] - customizing, infoinput

### DIFF
--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
@@ -323,7 +323,7 @@ extension TemplatePreviewBody {
                     .foregroundColor(.black)
             }
             .padding(.horizontal, 16)
-            .padding(.vertical, 12.5)
+            .padding(.vertical, 10.5)
         }
         .buttonStyle(.plain)
         .glassEffect(.regular.interactive(), in: .capsule)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/EffectSelectorView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/EffectSelectorView.swift
@@ -267,33 +267,7 @@ struct EffectSelectorView<VM: KeyringViewModelProtocol>: View {
                 HStack(spacing: 4) {
                     // 유료 아이콘
                     if !sound.isFree {
-                        if isOwned {
-                            // 유료 + 보유
-                            if isSelected {
-                                Image(.whiteEffectSelect)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 18, height: 18)
-                            } else {
-                                Image(.grayEffectSelect)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 18, height: 18)
-                            }
-                        } else {
-                            // 유료 + 미보유
-                            if isSelected {
-                                Image(.whiteEffectSelect)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 18, height: 18)
-                            } else {
-                                Image(.gradientEffectSelect)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 18, height: 18)
-                            }
-                        }
+                        Image(.myCoinMini)
                     }
 
                     Text(sound.soundName)
@@ -441,33 +415,7 @@ struct EffectSelectorView<VM: KeyringViewModelProtocol>: View {
                 HStack(spacing: 4) {
                     // 유료 아이콘
                     if !particle.isFree {
-                        if isOwned {
-                            // 유료 + 보유
-                            if isSelected {
-                                Image(.whiteEffectSelect)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 18, height: 18)
-                            } else {
-                                Image(.grayEffectSelect)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 18, height: 18)
-                            }
-                        } else {
-                            // 유료 + 미보유
-                            if isSelected {
-                                Image(.whiteEffectSelect)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 18, height: 18)
-                            } else {
-                                Image(.gradientEffectSelect)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 18, height: 18)
-                            }
-                        }
+                        Image(.myCoinMini)
                     }
 
                     Text(particle.particleName)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+PurchaseSheet.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+PurchaseSheet.swift
@@ -31,7 +31,7 @@ extension KeyringCustomizingView {
 
             /// 장바구니 리스트 (스크롤 가능)
             ScrollView {
-                VStack(spacing: 12) {
+                VStack(spacing: 20) {
                     ForEach(cartItems) { item in
                         purchaseItemRow(item: item)
                     }
@@ -43,7 +43,7 @@ extension KeyringCustomizingView {
             Spacer()
 
             // 내 보유 포인트
-            HStack(spacing: 4) {
+            HStack(spacing: 6) {
                 Text("내 보유 :")
                     .typography(.suit15M25)
                     .foregroundStyle(.black100)
@@ -51,8 +51,9 @@ extension KeyringCustomizingView {
                 Text("\(UserManager.shared.currentUser?.coin ?? 0)")
                     .typography(.nanum16EB)
                     .foregroundStyle(.main500)
+                    .padding(.top, 2)
             }
-            .padding(.bottom, 16)
+            .padding(.bottom, 7)
 
             // 구매 버튼
             purchaseButton
@@ -80,23 +81,23 @@ extension KeyringCustomizingView {
     /// 구매 아이템 Row
     private func purchaseItemRow(item: EffectItem) -> some View {
         HStack(spacing: 0) {
-            // 아이콘 (유료 표시)
-            Image(.mainEffectSelect)
-                .padding(.trailing, 6)
-
             // 아이템 이름
             Text(item.name)
-                .typography(.suit17B)
+                .typography(.suit16B)
                 .foregroundStyle(.black100)
                 .padding(.trailing, 6)
 
             // 타입 표시
             Text(item.type.rawValue)
-                .typography(.suit12M)
+                .typography(.suit13M)
                 .foregroundStyle(.gray400)
 
             Spacer()
 
+            // 아이콘 (유료 표시)
+            Image(.myCoinMini)
+                .padding(.trailing, 5)
+            
             // 가격
             Text("\(item.price)")
                 .typography(.nanum16EB)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView.swift
@@ -311,7 +311,7 @@ extension KeyringCustomizingView {
             } label: {
                 Text(hasCartItems ? "구매 \(cartItems.count)" : "다음")
                     .typography(.suit17B)
-                    .foregroundStyle(hasCartItems ? .white100 : .black100)
+                    .foregroundStyle(hasCartItems ? .white100 : .main500)
                     .padding(4.5)
             }
             .buttonStyle(.glassProminent)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+Helpers.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+Helpers.swift
@@ -72,7 +72,7 @@ extension KeyringInfoInputView {
             } label: {
                 Text("다음")
                     .typography(.suit17B)
-                    .foregroundStyle(viewModel.nameText.isEmpty || hasProfanity ? .gray300 : .black100)
+                    .foregroundStyle(viewModel.nameText.isEmpty || hasProfanity ? .gray300 : .main500)
                     .padding(5)
             }
             .buttonStyle(.glassProminent)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+Sheet.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+Sheet.swift
@@ -111,10 +111,14 @@ extension KeyringInfoInputView {
                     .typography(.notosans15M)
                     /// 커서 표시기 색상
                     .tint(.main500)
-
-                    Text("\(textCount)/\(viewModel.maxTextCount)")
-                        .typography(.suit13M)
-                        .foregroundStyle(.gray300)
+   
+                    if viewModel.nameText.count > 0 {
+                        Button {
+                            viewModel.nameText = ""
+                        } label: {
+                            Image(.emptyIcon)
+                        }
+                    }
                 }
                 .padding(.vertical, 13.5)
                 .padding(.horizontal, 16)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+TagManagement.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+TagManagement.swift
@@ -59,32 +59,41 @@ extension KeyringInfoInputView {
                 .typography(.suit17B)
                 .foregroundStyle(.black100)
                 .padding(.top, 14)
+                .padding(.bottom, 30)
             
-            // TextField
-            TextField("태그 이름을 입력해주세요", text: $newTagName)
-                .typography(.notosans15R)
-                .padding(.vertical, 14)
-                .padding(.horizontal, 16)
-                .frame(height: 52)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(.white100)
-                )
-                .padding(.top, 21)
-                .padding(.bottom, 5)
-                .onChange(of: newTagName) { oldValue, newValue in
-                    if newValue.count > 10 {
-                        newTagName = String(newValue.prefix(10))
+            HStack {
+                // TextField
+                TextField("태그 이름을 입력해주세요", text: $newTagName)
+                    .typography(.notosans16R)
+                    .onChange(of: newTagName) { oldValue, newValue in
+                        if newValue.count > 10 {
+                            newTagName = String(newValue.prefix(10))
+                        }
+                        showTagNameAlreadyExistsToast = availableTags.contains(newValue)
                     }
-                    showTagNameAlreadyExistsToast = availableTags.contains(newValue)
+                    .tint(.main500)
+                
+                if newTagName.count > 0 {
+                    Button {
+                        newTagName = ""
+                    } label: {
+                        Image(.emptyIcon)
+                    }
                 }
-                .tint(.main500)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.white100)
+            )
             
             HStack {
                 Text(showTagNameAlreadyExistsToast ? "이미 사용 중인 태그 이름입니다." : "")
                     .typography(.suit14M)
                     .foregroundStyle(.error)
                     .opacity(showTagNameAlreadyExistsToast ? 1 : 0)
+                    .padding(.top, showTagNameAlreadyExistsToast ? 5 : 0)
                 
                 Spacer()
             }
@@ -139,8 +148,8 @@ extension KeyringInfoInputView {
             }
         }
         .padding(14)
+        .frame(width: UIScreen.main.bounds.width - 102)  // 좌우 51씩 여백
         .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 34))
-        .frame(width: 300, height: 230)
     }
 }
 

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+TagManagement.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+TagManagement.swift
@@ -50,7 +50,7 @@ extension KeyringInfoInputView {
     }
 }
 
-// MARK: - Add Tag Alert (Glass Style)
+// MARK: - Add Tag Alert
 extension KeyringInfoInputView {
     var addNewTagAlertView: some View {
         VStack(spacing: 0) {
@@ -65,6 +65,7 @@ extension KeyringInfoInputView {
                 // TextField
                 TextField("태그 이름을 입력해주세요", text: $newTagName)
                     .typography(.notosans16R)
+                    .focused($isTagTextFieldFocused)
                     .onChange(of: newTagName) { oldValue, newValue in
                         if newValue.count > 10 {
                             newTagName = String(newValue.prefix(10))

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView.swift
@@ -36,6 +36,7 @@ struct KeyringInfoInputView<VM: KeyringViewModelProtocol>: View {
     @State var sheetDetent: PresentationDetent = .height(76)
     @State var showSheet: Bool = true
     @FocusState var isFocused: Bool
+    @FocusState var isTagTextFieldFocused: Bool
 
     // MARK: - Profanity Filtering
     @State var validationMessage: String = ""
@@ -111,6 +112,18 @@ struct KeyringInfoInputView<VM: KeyringViewModelProtocol>: View {
                 Color.black60
                     .ignoresSafeArea()
                     .zIndex(99)
+                    .onTapGesture {
+                        // 키보드가 올라와 있으면 키보드만 내림
+                        if isTagTextFieldFocused {
+                            isTagTextFieldFocused = false
+                        } else {
+                            // 키보드가 이미 내려가 있으면 Alert 닫기
+                            newTagName = ""
+                            showAddTagAlert = false
+                            showTagNameAlreadyExistsToast = false
+                            sheetDetent = .height(measuredSheetHeight)
+                        }
+                    }
 
                 addNewTagAlertView
                     .zIndex(100)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView.swift
@@ -113,7 +113,6 @@ struct KeyringInfoInputView<VM: KeyringViewModelProtocol>: View {
                     .zIndex(99)
 
                 addNewTagAlertView
-                    .padding(.horizontal, 51)
                     .zIndex(100)
             }
 


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 1. 커마뷰 - 유료 아이콘 변경
<img width="250" alt="커마뷰 - 유료아이템 아이콘 변경" src="https://github.com/user-attachments/assets/c72e911e-5462-4d6a-b847-6de3edd5f923" />

> 기존에는 총 3가지 에셋으로 진짜 심각한 분기를 했는데, 아주 깔끔하게 1개로 통일돼서 편안해짐.

### 2. 커마뷰 - 시트 UI 수정 
<img width="250" alt="커마뷰 - 시트 UI" src="https://github.com/user-attachments/assets/f5eef0ae-4720-4fb0-ba8e-a02a74d1db4d" />

> 대표적인 변화 -> 유료 아이콘이 오른쪽으로 감, 그외 하이파이 자잘하게 수정
**근데 뭔가 분명 기존에 하이파이 (패딩값, 폰트크기, 색상 등)를 완전하게 적용했던거같은데**
**왜 UI 조정하면서 보니까 뭔가 크기가 커졌거나 패딩값이 변했거나 한 부분들이 많은거같지**
**그래서 하나하나 다시 보게되어서 시간 더 걸리는듯**
`예전에 잘못 짰거나 / 잠수함 패치 했거나.`

### 3. 커마뷰 - 다음 색상 변경
<img width="250" alt="커마뷰 - 다음버튼 색상변경" src="https://github.com/user-attachments/assets/0384abf3-70d3-44ed-9f0a-2617445c41b3" />

### 4. 인포뷰 - 텍스트 초기화 추가

<img width="250" alt="인포뷰 - 텍스트 초기화 추가" src="https://github.com/user-attachments/assets/c722db6f-20bd-4307-a0ed-9944cf08ae4b" />

> 인포뷰 텍스트 초기화 버튼 추가 (텍스트 입력 시, 등장) 
이건 왜 지금까지 없었을까?
이건 없고, 하이파이엔 없는 텍스트 갯수 세는거만 있었음. << 이거 del.

<img width="250" alt="인포뷰 - 태그추가 alert" src="https://github.com/user-attachments/assets/bd54ac82-eb94-4c97-be0d-f513d4f28913" />

> 태그에도 추가 

### 5. 인포뷰 - 태그 alert 닫기 기능 

https://github.com/user-attachments/assets/b1236bbe-063b-477e-80d5-f7914fb94866

> 보니까 기존엔에는, 태그 alert 닫으려면 무조건 "취소" 눌러야함. 

그래서 추가한게, 
**1. 화면밖 터치하면, 키보드 내려감**
**2. 키보드 내려간 상태에서 화면 밖 터치하면, alert 닫힘.**

> 생각보다 "이슈탭 리스트" 보다 이슈가 더 있어서 유심하게 개발해야할 것 같습니다.

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #26 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
