### PR TITLE
fix: 커스텀 사운드 키링 영상 생성 실패 버그 수정

### DIFF
--- a/Keychy/Keychy/Core/Extensions/String+Extension.swift
+++ b/Keychy/Keychy/Core/Extensions/String+Extension.swift
@@ -13,4 +13,26 @@ extension String {
     var byCharWrapping: Self {
         map(String.init).joined(separator: "\u{200B}")
     }
+
+    /// Firebase Storage URL에서 파일명 추출
+    /// URL 형식: https://firebasestorage.googleapis.com/v0/b/.../o/path%2Fto%2Ffile.m4a?alt=media&token=xxx
+    var firebaseStorageFileName: String {
+        // /o/ 이후의 경로 추출
+        guard let oRange = range(of: "/o/") else {
+            return URL(string: self)?.lastPathComponent ?? "custom_sound.m4a"
+        }
+
+        // /o/ 이후부터 ? 이전까지 추출
+        var encodedPath = String(self[oRange.upperBound...])
+        if let queryIndex = encodedPath.firstIndex(of: "?") {
+            encodedPath = String(encodedPath[..<queryIndex])
+        }
+
+        // URL 디코딩
+        let decodedPath = encodedPath.removingPercentEncoding ?? encodedPath
+
+        // 마지막 경로 컴포넌트 (파일명) 추출
+        let components = decodedPath.components(separatedBy: "/")
+        return components.last ?? "custom_sound.m4a"
+    }
 }

--- a/Keychy/Keychy/Core/Firebase/EffectSyncManager.swift
+++ b/Keychy/Keychy/Core/Firebase/EffectSyncManager.swift
@@ -285,9 +285,8 @@ class EffectSyncManager {
             return
         }
 
-        // URL path에서 마지막 컴포넌트만 추출 (예: 6FBEABEA-F603-40EA-B953-7D2F0AA9EB03.m4a)
-        let pathComponents = downloadURL.path.components(separatedBy: "/")
-        let fileName = pathComponents.last ?? "custom_sound.m4a"
+        // Firebase Storage URL에서 파일명 추출
+        let fileName = soundURLString.firebaseStorageFileName
 
         let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
         let soundsDir = cacheDirectory.appendingPathComponent("sounds")
@@ -306,19 +305,12 @@ class EffectSyncManager {
 
         // 이미 다운로드되어 있으면 스킵
         if FileManager.default.fileExists(atPath: localURL.path) {
-            print("[EffectSync] 커스텀 사운드 이미 캐시에 있음: \(fileName)")
             return
         }
 
         do {
-            // URLSession으로 직접 다운로드
             let (tempURL, _) = try await URLSession.shared.download(from: downloadURL)
-
-            // 임시 파일을 최종 위치로 이동
             try FileManager.default.moveItem(at: tempURL, to: localURL)
-
-            print("[EffectSync] 커스텀 사운드 다운로드 완료: \(fileName)")
-
         } catch {
             print("[EffectSync] 커스텀 사운드 다운로드 실패 (\(fileName)): \(error.localizedDescription)")
         }

--- a/Keychy/Keychy/Core/Video/Keyring/KeyringVideoGenerator+Sound.swift
+++ b/Keychy/Keychy/Core/Video/Keyring/KeyringVideoGenerator+Sound.swift
@@ -77,18 +77,25 @@ extension KeyringVideoGenerator {
             }
 
             let audioAsset = AVURLAsset(url: soundURL)
-            guard let audioTrack = try await audioAsset.loadTracks(withMediaType: .audio).first else {
-                continue
+
+            do {
+                let tracks = try await audioAsset.loadTracks(withMediaType: .audio)
+
+                guard let audioTrack = tracks.first else {
+                    continue
+                }
+
+                let audioDuration = try await audioAsset.load(.duration)
+                let startTime = CMTime(seconds: event.time, preferredTimescale: 600)
+
+                try compositionAudioTrack?.insertTimeRange(
+                    CMTimeRange(start: .zero, duration: audioDuration),
+                    of: audioTrack,
+                    at: startTime
+                )
+            } catch {
+                print("[VideoGenerator] 오디오 트랙 삽입 실패: \(error.localizedDescription)")
             }
-
-            let audioDuration = try await audioAsset.load(.duration)
-            let startTime = CMTime(seconds: event.time, preferredTimescale: 600)
-
-            try compositionAudioTrack?.insertTimeRange(
-                CMTimeRange(start: .zero, duration: audioDuration),
-                of: audioTrack,
-                at: startTime
-            )
         }
 
         // 최종 비디오 Export
@@ -111,22 +118,29 @@ extension KeyringVideoGenerator {
     }
 
     /// 사운드 파일 URL 찾기
-    /// 1. Firebase 캐시 확인 (sounds/soundId.mp3)
-    /// 2. 커스텀 녹음 파일인 경우 URL 직접 반환
+    /// 1. Firebase Storage URL인 경우 (커스텀 사운드) 캐시에서 파일명으로 찾기
+    /// 2. 일반 사운드 ID인 경우 캐시에서 찾기
     private func findSoundURL(soundId: String) -> URL? {
-        // 커스텀 녹음 파일 (URL 형식)
-        if soundId.starts(with: "file://") || soundId.starts(with: "/") {
-            return URL(fileURLWithPath: soundId.replacingOccurrences(of: "file://", with: ""))
+        let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        let soundsDir = cacheDirectory.appendingPathComponent("sounds")
+
+        // 1. Firebase Storage URL (커스텀 사운드)
+        if soundId.hasPrefix("https://") || soundId.hasPrefix("http://") {
+            let fileName = soundId.firebaseStorageFileName
+            let cachedURL = soundsDir.appendingPathComponent(fileName)
+
+            guard FileManager.default.fileExists(atPath: cachedURL.path) else {
+                return nil
+            }
+            return cachedURL
         }
 
-        // Firebase 캐시
-        let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-        let cachedURL = cacheDirectory.appendingPathComponent("sounds/\(soundId).mp3")
+        // 2. 일반 사운드 ID (Firebase 캐시)
+        let cachedURL = soundsDir.appendingPathComponent("\(soundId).mp3")
 
         guard FileManager.default.fileExists(atPath: cachedURL.path) else {
             return nil
         }
-
         return cachedURL
     }
 }

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+FirebaseSave.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+FirebaseSave.swift
@@ -30,15 +30,21 @@ extension KeyringInfoInputView {
             
             // 2. 커스텀 사운드가 있으면 Firebase Storage에 업로드
             if let customSoundURL = self.viewModel.customSoundURL {
-                self.uploadSoundToStorage(soundURL: customSoundURL, uid: uid) { soundURL in
-                    guard let soundURL = soundURL else {
+                self.uploadSoundToStorage(soundURL: customSoundURL, uid: uid) { firebaseURL in
+                    guard let firebaseURL = firebaseURL else {
                         // 업로드 실패 시 기존 soundId 사용
                         self.createKeyringWithData(uid: uid, imageURL: imageURL, soundId: self.viewModel.soundId)
                         return
                     }
-                    
+
                     // 업로드 성공 - Firebase Storage URL을 soundId로 사용
-                    self.createKeyringWithData(uid: uid, imageURL: imageURL, soundId: soundURL)
+                    // viewModel도 업데이트하여 CompleteView에서 올바른 soundId 사용
+                    self.viewModel.soundId = firebaseURL
+
+                    // 로컬 사운드 파일을 캐시에 복사 (영상 생성 시 사용)
+                    self.copySoundToCache(localURL: customSoundURL, firebaseURL: firebaseURL)
+
+                    self.createKeyringWithData(uid: uid, imageURL: imageURL, soundId: firebaseURL)
                 }
             } else {
                 // 커스텀 사운드 없음 - 기존 soundId 사용
@@ -127,10 +133,10 @@ extension KeyringInfoInputView {
             completion(nil)
             return
         }
-        
+
         let fileName = "\(UUID().uuidString).m4a"
         let path = "Keyrings/CustomSounds/\(uid)/\(fileName)"
-        
+
         Task {
             do {
                 let downloadURL = try await StorageManager.shared.uploadAudio(soundData, path: path)
@@ -141,7 +147,35 @@ extension KeyringInfoInputView {
             }
         }
     }
-    
+
+    // MARK: - 로컬 사운드 파일을 캐시에 복사
+    /// 새로 생성된 키링의 커스텀 사운드를 영상 생성 시 사용할 수 있도록 캐시에 복사
+    private func copySoundToCache(localURL: URL, firebaseURL: String) {
+        let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        let soundsDir = cacheDirectory.appendingPathComponent("sounds")
+
+        // sounds 디렉토리 생성
+        if !FileManager.default.fileExists(atPath: soundsDir.path) {
+            try? FileManager.default.createDirectory(at: soundsDir, withIntermediateDirectories: true)
+        }
+
+        // Firebase URL에서 파일명 추출
+        let fileName = firebaseURL.firebaseStorageFileName
+        let destinationURL = soundsDir.appendingPathComponent(fileName)
+
+        do {
+            // 이미 존재하면 삭제
+            if FileManager.default.fileExists(atPath: destinationURL.path) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
+
+            // 로컬 파일을 캐시로 복사
+            try FileManager.default.copyItem(at: localURL, to: destinationURL)
+        } catch {
+            print("[SoundCache] 사운드 캐시 복사 실패: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - 새 키링 생성 및 User에 추가
     func createKeyring(
         uid: String,


### PR DESCRIPTION
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->
### 커스텀 사운드를 사용한 키링에서 영상 공유 시, 영상 생성이 실패하는 버그를 수정했씁니다.
> 일반 사운드(프리셋)를 사용한 키링만 정상 동작했음.
> **내용이 조금 복잡할 수 있는데, 마지막까지 읽으면 이해가 될 것 같습니다.**

## 원인 분석
### 1. Firebase Storage URL 파일명 추출 오류

**Firebase Storage URL 구조는 이렇습니다.**
> https://firebasestorage.googleapis.com/v0/b/.../o/Keyrings%2FCustomSounds%2Fuid%2FUUID.m4a?alt=media&token=xxx

**기존 코드 (EffectSyncManager.swift):**

```swift
let pathComponents = downloadURL.path.components(separatedBy: "/")
let fileName = pathComponents.last ?? "custom_sound.m4a"
```

**문제점**
- downloadURL.path는 **URL 인코딩된 전체 경로를 반환**
- path.last의 결과: Keyrings%2FCustomSounds%2Fuid%2FUUID.m4a (잘못된 파일명)
- 실제 필요한 파일명: UUID.m4a

KeyringVideoGenerator도 동일한 문제:
- file:// 또는 / 시작 경로만 처리하고, https:// Firebase URL은 처리하지 못했음.

### 2. 새로 생성된 키링의 사운드가 캐시에 없음

키링 생성 플로우는 아래와 같습니다.
> 녹음 → Firebase 업로드 → Firestore 저장 → CompleteView → 공유 클릭

**문제점**
- **1. EffectSyncManager는 보관함에서 키링 조회 시에만 사운드를 다운로드**
- **2. 새로 만든 키링은 CompleteView에서 바로 공유하므로 캐시에 사운드 파일이 없음**
- **3. KeyringVideoGenerator가 캐시에서 파일을 찾지 못해 실패!**

### 3. viewModel.soundId가 업데이트되지 않음

**기존 코드**
```swift
  self.uploadSoundToStorage(soundURL: customSoundURL, uid: uid) { soundURL in
      // soundURL = Firebase Storage URL
      self.createKeyringWithData(uid: uid, imageURL: imageURL, soundId: soundURL)
      // viewModel.soundId는 여전히 "custom_recording"
  }
  ```
> Firestore에는 Firebase URL이 저장되지만, viewModel.soundId는 "custom_recording" 그대로
> CompleteView에서 영상 생성 시 "custom_recording"으로 사운드를 찾으려 함


**결론적으로,** 
**아래 플로우대로 수정이 되어야 합니다.**
> 녹음 → Firebase 업로드 → **로컬 파일을 캐시에 복사 (추가)** → Firestore 저장 → CompleteView → 공유 클릭

## 해결! 
### 1. Firebase Storage URL 파일명 추출 로직 수정 (+공용화)

`String+Extension.swift`

```swift
extension String {
	var firebaseStorageFileName: String {
		// /o/ 이후의 경로 추출
		guard let oRange = range(of: "/o/") else {
			return URL(string: self)?.lastPathComponent ?? "custom_sound.m4a"
		}

        // /o/ 이후부터 ? 이전까지 추출
        var encodedPath = String(self[oRange.upperBound...])
        if let queryIndex = encodedPath.firstIndex(of: "?") {
            encodedPath = String(encodedPath[..<queryIndex])
        }

        // URL 디코딩 후 마지막 컴포넌트 추출
        let decodedPath = encodedPath.removingPercentEncoding ?? encodedPath
        return decodedPath.components(separatedBy: "/").last ?? "custom_sound.m4a"
	}
}
```

**파일명 추출 동작**
```swift
// Before
let pathComponents = downloadURL.path.components(separatedBy: "/")
let fileName = pathComponents.last ?? "custom_sound.m4a"

// After
let fileName = soundURLString.firebaseStorageFileName
> 결과 -> "UUID.m4a"
```

### 2. 새로 생성된 키링의 사운드를 캐시에 복사

```swift
KeyringInfoInputView+FirebaseSave.swift

private func copySoundToCache(localURL: URL, firebaseURL: String) {
    let soundsDir = cacheDirectory.appendingPathComponent("sounds")
    let fileName = firebaseURL.firebaseStorageFileName
    let destinationURL = soundsDir.appendingPathComponent(fileName)

    try FileManager.default.copyItem(at: localURL, to: destinationURL)
}

이후, viewModel.soundId 업데이트를 해주고 URL 추출 처리를 해주면 됩니다.

### 왜 이런 과정이 필요한가? 

단순히, **사운드 재생(스트리밍)**을 위한 것과 **영상 재생**을 위한 것은 차이가 존재했습니다.

#### 1. 실시간 재생 (AVPlayer)
> Firebase URL을 직접 스트리밍하여 재생

- 네트워크에서 실시간으로 오디오 데이터를 받아 재생
- 로컬 파일 없이도 동작

#### 2. 영상 생성 (AVMutableComposition)
> // 오디오 트랙을 비디오에 합성

```swift
let audioAsset = AVURLAsset(url: soundURL)
let audioTrack = try await audioAsset.loadTracks(withMediaType: .audio).first
compositionAudioTrack.insertTimeRange(..., of: audioTrack, at: startTime)
```

- AVMutableComposition은 오디오/비디오 트랙을 파일 시스템에서 직접 읽어 합성
- Firebase URL을 넣으면 트랙 로드 실패 → 에러 -11838
- 반드시 로컬 캐시 파일이 필요

### 결론

키링 씬에서 사운드가 정상 재생되더라도, 
**영상 생성 시에는 동일한 사운드 파일이 로컬 캐시에 존재해야 합니다.** 
**새로 생성된 키링의 커스텀 사운드를 즉시 캐시에 복사**하여, 완성뷰에서 바로 영상 공유가 가능하도록 한 것,.


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

<img width="230" alt="스크린샷, 2026-02-09 14 36 25" src="https://github.com/user-attachments/assets/f86e89d9-1632-4245-85af-25154d40211f" />

> 잘 됩니다!


## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #60 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
