### PR TITLE
fix: 뭉치 상세뷰 이름 변경뷰에서 뒤로가기 시 무한로딩 현상 픽스

### DIFF
--- a/Keychy/Keychy/Presentation/Bundle/Views/Detail/BundleDetailView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Detail/BundleDetailView.swift
@@ -98,7 +98,7 @@ struct BundleDetailView<Route: BundleRoute>: View {
                         )
                         .animation(.easeInOut(duration: 0.3), value: isSceneReady)
                         /// 씬 재생성 조건을 위한 ID 설정 -> 배경, 카라비너, 키링 구성이 변경되면 씬을 완전히 재생성
-                        .id("scene_\(background.id ?? "")_\(carabiner.id ?? "")_\(keyringDataList.map { "\($0.index)_\($0.bodyImageURL.hashValue)" }.joined(separator: "_"))_\(sceneReloadTrigger.uuidString)")
+                        .id(sceneId(background: background, carabiner: carabiner))
                         
                         VStack {
                             Spacer()
@@ -345,6 +345,19 @@ extension BundleDetailView {
                 "\(item.index)|\(item.bodyImageURL)|\((item.templateId ?? ""))|\(item.soundId)|\(item.particleId)"
             }
             .joined(separator: ";")
+    }
+    
+    private func sceneId(
+        background: Background,
+        carabiner: Carabiner
+    ) -> String {
+        let bgId = background.id ?? ""
+        let cbId = carabiner.id ?? ""
+        let krIds = keyringDataList
+            .map { "\($0.index)_\($0.bodyImageURL.hashValue)" }
+            .joined(separator: "_")
+        
+        return "scene_\(bgId)_\(cbId)_\(krIds)_\(sceneReloadTrigger.uuidString)"
     }
 }
 

--- a/Keychy/Keychy/Presentation/Bundle/Views/Detail/BundleDetailView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Detail/BundleDetailView.swift
@@ -43,6 +43,7 @@ struct BundleDetailView<Route: BundleRoute>: View {
     @State var isNavigatingDeeper: Bool = true
     @State private var dismissTask: Task<Void, Never>?
     @State private var readyDelayTask: Task<Void, Never>?
+    @State private var sceneReloadTrigger = UUID()
     
     /// MultiKeyringScene에 전달할 키링 데이터 리스트
     @State var keyringDataList: [MultiKeyringScene.KeyringData] = []
@@ -97,14 +98,7 @@ struct BundleDetailView<Route: BundleRoute>: View {
                         )
                         .animation(.easeInOut(duration: 0.3), value: isSceneReady)
                         /// 씬 재생성 조건을 위한 ID 설정 -> 배경, 카라비너, 키링 구성이 변경되면 씬을 완전히 재생성
-                        .id("scene_\(background.id ?? "")_\(carabiner.id ?? "")_\(keyringDataList.map { "\($0.index)_\($0.bodyImageURL.hashValue)" }.joined(separator: "_"))")
-                        .onAppear {
-                            bundleVM.returnBackgroundId = bundle.selectedBackground
-                            bundleVM.returnCarabinerId = bundle.selectedCarabiner
-                            bundleVM.returnKeyringsId = bundle.keyrings
-                                .sorted()
-                                .joined(separator: "|")
-                        }
+                        .id("scene_\(background.id ?? "")_\(carabiner.id ?? "")_\(keyringDataList.map { "\($0.index)_\($0.bodyImageURL.hashValue)" }.joined(separator: "_"))_\(sceneReloadTrigger.uuidString)")
                         
                         VStack {
                             Spacer()

--- a/Keychy/Keychy/Presentation/Bundle/Views/Detail/BundleDetailView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Detail/BundleDetailView.swift
@@ -90,12 +90,6 @@ struct BundleDetailView<Route: BundleRoute>: View {
                                             withAnimation(.easeOut(duration: 0.3)) {
                                                 isSceneReady = true
                                             }
-                                            // 마지막으로 로드한 구성 id를 뷰모델에 저장 (뷰모델이 다음 진입 시 동일 구성 판정)
-                                            bundleVM.updateLastConfigIds(
-                                                background: bundleVM.selectedBackground,
-                                                carabiner: bundleVM.selectedCarabiner,
-                                                keyringDataList: keyringDataList
-                                            )
                                         }
                                     }
                                 }
@@ -222,6 +216,17 @@ extension BundleDetailView {
         let newKeyringDataList = await bundleVM.createKeyringDataList(bundle: bundle, carabiner: carabiner)
         keyringDataList = newKeyringDataList
         
+        // 항상 lastConfigIds 업데이트
+        let bgId = bundleVM.makeBackgroundId(bundleVM.selectedBackground)
+        let cbId = bundleVM.makeCarabinerId(bundleVM.selectedCarabiner)
+        let krId = bundleVM.makeKeyringsId(newKeyringDataList)
+        
+        bundleVM.lastBackgroundIdForDetail = bgId
+        bundleVM.lastCarabinerIdForDetail = cbId
+        bundleVM.lastKeyringsIdForDetail = krId
+        
+        sceneReloadTrigger = UUID()
+        
         // 키링 데이터까지 불러오고 난 후에도 키링의 개수가 0개라면 바로 씬을 준비 완료 상태로 체크
         if newKeyringDataList.isEmpty {
             isSceneReady = true
@@ -289,12 +294,17 @@ extension BundleDetailView {
     @MainActor
     private func handleBundleChange() async {
         guard let bundle = bundleVM.selectedBundle else { return }
+        
         // 동일 구성인지 확인(+변경 감지)
-        if bundleVM.shouldSkipReloadForReturnedConfig() {
+        let shouldSkip = bundleVM.shouldSkipReloadForReturnedConfig()
+        
+        if shouldSkip {
             restoreSceneIfNeeded(bundle)
             isSceneReady = true
             return
         }
+        
+        // 리로드 진행 - loadBundleData 호출
         isSceneReady = false
         readyDelayTask?.cancel()
         readyDelayTask = nil
@@ -312,6 +322,19 @@ extension BundleDetailView {
         if bundleVM.selectedCarabiner == nil {
             bundleVM.selectedCarabiner = bundleVM.resolveCarabiner(from: bundle.selectedCarabiner)
         }
+        
+        // keyringDataList도 복원 (NameEditView에서 돌아올 때 필요)
+        if keyringDataList.isEmpty, let carabiner = bundleVM.selectedCarabiner {
+            Task {
+                let newKeyringDataList = await bundleVM.createKeyringDataList(bundle: bundle, carabiner: carabiner)
+                await MainActor.run {
+                    keyringDataList = newKeyringDataList
+                    isSceneReady = true
+                }
+            }
+            return
+        }
+        
         readyDelayTask?.cancel()
         readyDelayTask = nil
         isSceneReady = true

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
@@ -246,6 +246,10 @@ extension BundleEditView {
     private var customNavigationBar: some View {
         CustomNavigationBar {
             BackToolbarButton {
+                bundleVM.lastBackgroundIdForDetail = ""
+                bundleVM.lastCarabinerIdForDetail = ""
+                bundleVM.lastKeyringsIdForDetail = ""
+                
                 isNavigatingAway = true
                 router.pop()
             }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleNameEditView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleNameEditView.swift
@@ -54,6 +54,16 @@ struct BundleNameEditView<Route: BundleRoute>: View {
                 morePadding = 40
             }
             TabBarManager.hide()
+            
+            Task {
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    bundleVM.fetchAllBackgrounds { _ in
+                        bundleVM.fetchAllCarabiners { _ in
+                            continuation.resume()
+                        }
+                    }
+                }
+            }
         }
         // 키보드 높이 변경 시 SwiftUI 애니메이션 비활성화
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
@@ -150,7 +160,36 @@ extension BundleNameEditView {
     private var customNavigationBar: some View {
         CustomNavigationBar {
             BackToolbarButton {
-                router.pop()
+                
+                if let bundle = bundleVM.selectedBundle {
+                    // resolveBackground/Carabiner가 nil을 반환할 수 있으므로 확인
+                    guard let bg = bundleVM.resolveBackground(from: bundle.selectedBackground),
+                          let cb = bundleVM.resolveCarabiner(from: bundle.selectedCarabiner) else {
+                        router.pop()
+                        return
+                    }
+                    
+                    let bgId = bundleVM.makeBackgroundId(bg)
+                    let cbId = bundleVM.makeCarabinerId(cb)
+                    
+                    bundleVM.returnBackgroundId = bgId
+                    bundleVM.returnCarabinerId = cbId
+                    
+                    Task {
+                        var krList: [MultiKeyringScene.KeyringData] = []
+                        krList = await bundleVM.createKeyringDataList(bundle: bundle, carabiner: cb)
+                        let krId = bundleVM.makeKeyringsId(krList)
+                        
+                        await MainActor.run {
+                            bundleVM.returnKeyringsId = krId
+                            // returnIds 설정 완료, pop
+                            router.pop()
+                        }
+                    }
+                } else {
+                    // bundle이 nil, 바로 pop
+                    router.pop()
+                }
             }
         } center: {
             EmptyView()
@@ -182,8 +221,8 @@ extension BundleNameEditView {
         let bgId = bundleVM.makeBackgroundId(bg)
         let cbId = bundleVM.makeCarabinerId(cb)
         
-        // keyringsId는 현재 번들의 구성 기반으로 재구성
         Task {
+            // returnIds 먼저 설정
             var krList: [MultiKeyringScene.KeyringData] = []
             if let carabiner = cb {
                 krList = await bundleVM.createKeyringDataList(bundle: bundle, carabiner: carabiner)
@@ -195,14 +234,15 @@ extension BundleNameEditView {
                 bundleVM.returnCarabinerId = cbId
                 bundleVM.returnKeyringsId = krId
             }
-        }
-        
-        bundleVM.updateBundleName(bundle: bundle, newName: bundleName.trimmingCharacters(in: .whitespacesAndNewlines)) { success in
-            DispatchQueue.main.async {
-                self.isUpdating = false
-                if success {
-                    bundleVM.selectedBundle?.name = self.bundleName.trimmingCharacters(in: .whitespacesAndNewlines)
-                    router.pop()
+            
+            // returnIds 설정 완료 후 이름 업데이트
+            bundleVM.updateBundleName(bundle: bundle, newName: bundleName.trimmingCharacters(in: .whitespacesAndNewlines)) { success in
+                DispatchQueue.main.async {
+                    self.isUpdating = false
+                    if success {
+                        bundleVM.selectedBundle?.name = self.bundleName.trimmingCharacters(in: .whitespacesAndNewlines)
+                        router.pop()
+                    }
                 }
             }
         }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleNameEditView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleNameEditView.swift
@@ -194,11 +194,27 @@ extension BundleNameEditView {
         } center: {
             EmptyView()
         } trailing: {
-            NextToolbarButton {
-                handleCheckButtonTap()
-            }
-            .disabled(isUpdating || bundleName.isEmpty || bundleName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || hasProfanity)
+            completeButton
         }
+    }
+    
+    private var completeButton: some View {
+        let isCompleteEnabled = !isUpdating &&
+                               !bundleName.isEmpty &&
+                               !bundleName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+                               !hasProfanity
+        
+        return Button {
+            guard isCompleteEnabled else { return }
+            handleCheckButtonTap()
+        } label: {
+            Text("완료")
+                .typography(.suit17B)
+                .foregroundStyle(isCompleteEnabled ? .main500 : .gray200)
+        }
+        .frame(width: 62, height: 44)
+        .glassEffect(.regular.interactive(), in: .capsule)
+        .disabled(!isCompleteEnabled)
     }
     
     private func handleCheckButtonTap() {


### PR DESCRIPTION
## 🎯 PR 내용
### ⚠️ 문제 상황
BundleDetailView에서 BundleEditView 또는 BundleNameEditView로 진입 후 백버튼으로 돌아올 때 무한 로딩에 걸리는 현상 발생
BundleNameEditView의 경우, 백버튼을 눌렀을 때와 수정 완료 버튼을 눌렀을 때 두 케이스 모두 무한로딩 발생함

재현 방법:
BundleDetailView → BundleNameEditView → 백버튼or완료버튼 → 무한 로딩 ⭕️
BundleDetailView → BundleEditView → 백버튼 → BundleNameEditView → 백버튼 → 무한 로딩 ❌

### 🔍 원인 분석
**1. ID 형식 불일치 문제**
- 편집 화면에서 돌아올 때 설정하는 returnIds와 DetailView에서 관리하는 lastConfigIds의 형식이 불일치
```swift
// NameEditView가 설정한 returnIds
returnBackgroundId: "WhiteKeychy"
returnCarabinerId: "PawPink|38.33|151.61|334.6"  // 좌표 포함
returnKeyringsId: "0|https://...|AcrylicPhoto|..."  // 상세 정보

// DetailView의 lastConfigIds (기존)
lastBackgroundIdForDetail: "WhiteKeychy"
lastCarabinerIdForDetail: "PawPink"  // 좌표 없음
lastKeyringsIdForDetail: "B7Bm2fNNkkUuLoYz3qyj|c42R5vHOiTA1snkWAPEO|..."  // Firebase ID만
```

**2. ID 업데이트 타이밍 문제**
- `MultiKeyringSceneView.onAllKeyringsReady`에서 `updateLastConfigIds()` 호출
- `loadBundleData()`에서도 `lastConfigIds` 업데이트 시도
- 결과: 두 곳에서 서로 다른 형식으로 ID를 설정하여 충돌 발생

**3. EditView 백버튼의 누락**
- EditView의 완료 버튼: returnIds 설정 → 정상 작동 ✅
- EditView의 백버튼: returnIds 미설정 → 불일치 발생 → 무한 로딩 ❌

**4. EditView에서 백버튼으로 돌아올 때 Scene 재생성 문제**
- keyringDataList는 업데이트됨
- Scene의 .id()는 동일 → SwiftUI가 Scene을 재생성하지 않음
- onAllKeyringsReady 콜백이 호출되지 않음
- isSceneReady가 false로 유지 → 무한 로딩

### 🛠️ 해결 방법
**1. ID 생성 로직 통일**
모든 화면에서 makeBackgroundId(), makeCarabinerId(), makeKeyringsId() 사용:
```swift
// 편집 화면들 (EditView, NameEditView)
let bgId = bundleVM.makeBackgroundId(background)
let cbId = bundleVM.makeCarabinerId(carabiner)
let krId = bundleVM.makeKeyringsId(keyringDataList)

bundleVM.returnBackgroundId = bgId
bundleVM.returnCarabinerId = cbId
bundleVM.returnKeyringsId = krId
```

**2. lastConfigIds 업데이트 단일화**
`onAllKeyringsReady`에서의 `updateLastConfigIds()` 호출을 제거하고, `loadBundleData()`에서만 업데이트

**3. EditView 백버튼 처리**
```swift
BackToolbarButton {
    // lastConfigIds 초기화 → 무조건 리로드
    bundleVM.lastBackgroundIdForDetail = ""
    bundleVM.lastCarabinerIdForDetail = ""
    bundleVM.lastKeyringsIdForDetail = ""
    
    isNavigatingAway = true
    router.pop()
}
```

**4. Scene 강제 재생성**
Scene을 생성할 때 id에 따라 생성하므로,`sceneReloadTrigger`를 추가하여 `loadBundleData()` 완료 시 Scene이 항상 재생성되도록 보장
```swift
@State private var sceneReloadTrigger = UUID()

// Scene ID에 포함
.id("scene_\(background.id ?? "")_\(carabiner.id ?? "")_\(...)_\(sceneReloadTrigger.uuidString)")

// loadBundleData()에서 업데이트
sceneReloadTrigger = UUID()
```



## 📱 스크린샷 (UI 변경 시)

> 뭉치 이름 변경

https://github.com/user-attachments/assets/c45aff4d-cae0-43a2-82ab-3b2bbcabe5a8


> 뭉치 수정

https://github.com/user-attachments/assets/6228900f-b0f0-4f4b-a669-3706531aed6a



## 🔗 관련 이슈
#23 

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
