### PR TITLE
fix: 최근템플릿 선택 -> 상세 프리뷰로 가던 문제 해결

### DIFF
--- a/Keychy/Keychy/Presentation/Workshop/Views/Main/WorkshopView+TopSection.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Views/Main/WorkshopView+TopSection.swift
@@ -112,8 +112,11 @@ extension WorkshopView {
             templates: viewModel.recentTemplates,
             isLoading: viewModel.isLoading
         ) { template in
-            // 템플릿 상세 프리뷰로 이동
-            router.push(.workshopPreview(item: template))
+            // 템플릿별 만들기 화면으로 이동
+            if let templateId = template.id,
+               let route = WorkshopRoute.from(string: templateId) {
+                router.push(route)
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 수정 전
<img width="200" alt="image" src="https://github.com/user-attachments/assets/8944b445-0220-456a-b3bb-762ceed7f605" />

기존에 `최근 템플릿 아이템` ---> `아이템프리뷰`로 잘못 보내고 있었음.   
그래서 화면처럼 최근 템플릿 아이템 눌렀는데 먼 보유중으로 뜨고있음.

### 수정 후
https://github.com/user-attachments/assets/87012043-d608-4dff-9db5-14740a51ac80

`최근 템플릿 아이템`---> `템플릿별 만들기 화면`으로 보냄.


> 이런 실수를 하다니, 더 꼼꼼하게 테스트하도록 하자..

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #68  

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
