### PR TITLE
fix: 앱 실행 시 로딩 Alert 안 뜨는 버그 + 빈 뭉치 전환 무한로딩 버그 수정

### DIFF
--- a/Keychy/Keychy/Core/KeyringBundle/View/MultiKeyringSceneView.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/View/MultiKeyringSceneView.swift
@@ -85,11 +85,6 @@ struct MultiKeyringSceneView: View {
                 loadBackgroundImage()
                 setupScene()
             }
-
-            // 키링이 없으면 즉시 준비 완료 콜백 호출
-            if keyringDataList.isEmpty {
-                onAllKeyringsReady?()
-            }
         }
         .onChange(of: backgroundImageURL) { _, _ in
             loadBackgroundImage()

--- a/Keychy/Keychy/Presentation/Home/ViewModels/HomeViewModel.swift
+++ b/Keychy/Keychy/Presentation/Home/ViewModels/HomeViewModel.swift
@@ -247,6 +247,10 @@ class HomeViewModel {
 
     /// 키링 데이터 변경 감지 시 씬 준비 상태 초기화
     func handleKeyringDataChange() {
+        // 빈 뭉치면 이미 createKeyringDataList에서 isSceneReady = true 설정됨
+        // 다시 false로 리셋하면 무한로딩 발생
+        guard !keyringDataList.isEmpty else { return }
+
         withAnimation(.easeIn(duration: 0.2)) {
             isSceneReady = false
         }


### PR DESCRIPTION
- handleKeyringDataChange에서 빈 뭉치일 때 isSceneReady 리셋 방지
- createKeyringDataList에서 설정한 isSceneReady = true가 유지되도록 함
- MultiKeyringSceneView의 불필요한 onAppear 체크 로직 제거

<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

**앱 실행 시 로딩 Alert 안 뜨는 버그 + 빈 뭉치 전환 무한로딩 버그 수정**

  ## 원인 분석

  ### 1차 문제: 앱 실행 시 로딩 Alert 안 뜸

  1. MultiKeyringSceneView.onAppear 실행
  2. keyringDataList.isEmpty 체크 → true (데이터 로딩 중이라 비어있음)
  3. onAllKeyringsReady() 즉시 호출
  4. 0.5초 후 isSceneReady = true
  5. 로딩 Alert 사라짐 (데이터 로딩 중인데!)
  
> 여기가 어제 메인뭉치 수정 후, 무한로딩 해결하려고 추가했던 로직

  → 해결: onAppear의 isEmpty 체크 제거 

  ### 2차 문제: 빈 뭉치 전환 시 무한로딩

  1. switchBundle → createKeyringDataList → isSceneReady = true 
  2. keyringDataList = [] 설정
  3. onChange(of: keyringDataList) 트리거
  4. handleKeyringDataChange() → isSceneReady = false  (덮어씀!)
  5. 키링 없어서 onAllKeyringsReady 호출 안됨
  6. 무한로딩

  → 해결: 빈 뭉치일 때 isSceneReady 리셋 방지

  ## 변경사항

  ```swift
  // MultiKeyringSceneView.swift - onAppear에서 제거
  - if keyringDataList.isEmpty {
  -     onAllKeyringsReady?()
  - }
```

```swift
  // HomeViewModel.swift
  func handleKeyringDataChange() {
  +   guard !keyringDataList.isEmpty else { return }
      withAnimation(.easeIn(duration: 0.2)) {
          isSceneReady = false
      }
  }
```

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #80 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
