### PR TITLE
feat: 이펙트 캐시 무효화 및 기타 개선

### DIFF
--- a/Keychy/Keychy/Core/Components/View/Popup/BundleSwitchPopup.swift
+++ b/Keychy/Keychy/Core/Components/View/Popup/BundleSwitchPopup.swift
@@ -119,7 +119,11 @@ struct BundleSwitchButton: View {
     let onTap: () -> Void
 
     var body: some View {
-        Button(action: onTap) {
+        Button {
+            if isEnabled {
+                onTap()
+            }
+        } label: {
             HStack(spacing: 12) {
                 Text(bundleName)
                     .typography(.nanum24EB)
@@ -139,6 +143,5 @@ struct BundleSwitchButton: View {
             }
         }
         .buttonStyle(.plain)
-        .disabled(!isEnabled)
     }
 }

--- a/Keychy/Keychy/Core/FileManagers/EffectManager.swift
+++ b/Keychy/Keychy/Core/FileManagers/EffectManager.swift
@@ -9,6 +9,7 @@ import Foundation
 import FirebaseStorage
 import FirebaseFirestore
 import AVFoundation
+import Lottie
 
 /// 이펙트(사운드, 파티클) 다운로드 및 재생을 관리하는 매니저
 @MainActor
@@ -69,6 +70,11 @@ class EffectManager {
         // 이미 다운로드 중이면 무시
         guard !downloadingItemIds.contains(soundId) else { return }
 
+        // 캐시 검증: 파일이 존재하고 URL이 일치하면 다운로드 스킵
+        if isInCache(soundId: soundId) && isCacheValid(id: soundId, currentURL: sound.soundData, type: .sound) {
+            return
+        }
+
         // 다운로드 시작
         downloadingItemIds.insert(soundId)
         downloadProgress[soundId] = 0.0
@@ -124,6 +130,9 @@ class EffectManager {
         // 사운드 프리로드 (재생 준비)
         await SoundEffectComponent.shared.preloadSound(named: soundId)
 
+        // 캐시 URL 저장 (다음 번 검증용)
+        saveCacheURL(id: soundId, url: sound.soundData, type: .sound)
+
         // 다운로드 상태 초기화
         downloadingItemIds.remove(soundId)
         downloadProgress.removeValue(forKey: soundId)
@@ -135,6 +144,11 @@ class EffectManager {
 
         // 이미 다운로드 중이면 무시
         guard !downloadingItemIds.contains(particleId) else { return }
+
+        // 캐시 검증: 파일이 존재하고 URL이 일치하면 다운로드 스킵
+        if isInCache(particleId: particleId) && isCacheValid(id: particleId, currentURL: particle.particleData, type: .particle) {
+            return
+        }
 
         // 다운로드 시작
         downloadingItemIds.insert(particleId)
@@ -187,6 +201,12 @@ class EffectManager {
             try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
             attempts += 1
         }
+
+        // 캐시 URL 저장 (다음 번 검증용)
+        saveCacheURL(id: particleId, url: particle.particleData, type: .particle)
+
+        // Lottie 애니메이션 캐시 클리어 (새 파일 로드를 위해)
+        LottieAnimationCache.shared?.clearCache()
 
         // 다운로드 상태 초기화
         downloadingItemIds.remove(particleId)
@@ -260,6 +280,31 @@ class EffectManager {
             case .particle: return "particleEffects"
             }
         }
+    }
+
+    // MARK: - Cache URL Validation
+
+    /// 캐시된 URL을 저장하는 UserDefaults 키
+    private func cacheURLKey(for id: String, type: ItemType) -> String {
+        switch type {
+        case .sound: return "cachedSoundURL_\(id)"
+        case .particle: return "cachedParticleURL_\(id)"
+        }
+    }
+
+    /// 캐시가 유효한지 확인 (파일 존재 + URL 일치)
+    private func isCacheValid(id: String, currentURL: String, type: ItemType) -> Bool {
+        let key = cacheURLKey(for: id, type: type)
+        guard let savedURL = UserDefaults.standard.string(forKey: key) else {
+            return false
+        }
+        return savedURL == currentURL
+    }
+
+    /// 캐시 URL 저장
+    private func saveCacheURL(id: String, url: String, type: ItemType) {
+        let key = cacheURLKey(for: id, type: type)
+        UserDefaults.standard.set(url, forKey: key)
     }
 
     /// UserManager의 유저 데이터 새로고침

--- a/Keychy/Keychy/Core/Firebase/EffectSyncManager.swift
+++ b/Keychy/Keychy/Core/Firebase/EffectSyncManager.swift
@@ -10,6 +10,7 @@
 import Foundation
 import FirebaseFirestore
 import FirebaseStorage
+import Lottie
 
 @Observable
 class EffectSyncManager {
@@ -169,14 +170,11 @@ class EffectSyncManager {
 
             print("[EffectSync] 구매한 사운드: \(soundEffects.count)개")
 
-            // 병렬 다운로드
+            // 병렬 다운로드 (URL 검증은 downloadSoundIfNeeded 내부에서 처리)
             await withTaskGroup(of: Void.self) { group in
                 for soundId in soundEffects {
-                    // 캐시에 없으면 다운로드
-                    if !isInCache(soundId: soundId) {
-                        group.addTask {
-                            await self.downloadSoundIfNeeded(soundId: soundId)
-                        }
+                    group.addTask {
+                        await self.downloadSoundIfNeeded(soundId: soundId)
                     }
                 }
             }
@@ -202,14 +200,11 @@ class EffectSyncManager {
 
             print("[EffectSync] 구매한 파티클: \(particleEffects.count)개")
 
-            // 병렬 다운로드
+            // 병렬 다운로드 (URL 검증은 downloadParticleIfNeeded 내부에서 처리)
             await withTaskGroup(of: Void.self) { group in
                 for particleId in particleEffects {
-                    // 캐시에 없으면 다운로드
-                    if !isInCache(particleId: particleId) {
-                        group.addTask {
-                            await self.downloadParticleIfNeeded(particleId: particleId)
-                        }
+                    group.addTask {
+                        await self.downloadParticleIfNeeded(particleId: particleId)
                     }
                 }
             }
@@ -218,7 +213,7 @@ class EffectSyncManager {
         }
     }
 
-    /// 사운드 다운로드 (캐시에 없을 때만)
+    /// 사운드 다운로드 (캐시에 없거나 URL이 변경된 경우)
     private func downloadSoundIfNeeded(soundId: String) async {
         // soundId가 URL 형태인지 확인 (커스텀 사운드)
         if soundId.hasPrefix("http://") || soundId.hasPrefix("https://") {
@@ -228,13 +223,6 @@ class EffectSyncManager {
 
         // 번들에 있으면 스킵 (무료 이펙트)
         if isInBundle(soundId: soundId) {
-            print("[EffectSync] 사운드 번들에 있음 (스킵): \(soundId)")
-            return
-        }
-
-        // 캐시에 있으면 스킵
-        guard !isInCache(soundId: soundId) else {
-            print("[EffectSync] 사운드 이미 캐시에 있음: \(soundId)")
             return
         }
 
@@ -249,6 +237,11 @@ class EffectSyncManager {
                   let soundURLString = soundData["soundData"] as? String,
                   let downloadURL = URL(string: soundURLString) else {
                 print("[EffectSync] soundData URL 없음: \(soundId)")
+                return
+            }
+
+            // 캐시 검증: 파일이 존재하고 URL이 일치하면 스킵
+            if isInCache(soundId: soundId) && isCacheValid(id: soundId, currentURL: soundURLString, type: .sound) {
                 return
             }
 
@@ -270,6 +263,9 @@ class EffectSyncManager {
                 try FileManager.default.removeItem(at: localURL)
             }
             try FileManager.default.moveItem(at: tempURL, to: localURL)
+
+            // 캐시 URL 저장
+            saveCacheURL(id: soundId, url: soundURLString, type: .sound)
 
             print("[EffectSync] 사운드 다운로드 완료: \(soundId)")
 
@@ -316,17 +312,10 @@ class EffectSyncManager {
         }
     }
 
-    /// 파티클 다운로드 (캐시에 없을 때만)
+    /// 파티클 다운로드 (캐시에 없거나 URL이 변경된 경우)
     private func downloadParticleIfNeeded(particleId: String) async {
         // 번들에 있으면 스킵 (무료 이펙트)
         if isInBundle(particleId: particleId) {
-            print("[EffectSync] 파티클 번들에 있음 (스킵): \(particleId)")
-            return
-        }
-
-        // 캐시에 있으면 스킵
-        guard !isInCache(particleId: particleId) else {
-            print("[EffectSync] 파티클 이미 캐시에 있음: \(particleId)")
             return
         }
 
@@ -341,6 +330,11 @@ class EffectSyncManager {
                   let particleURLString = particleData["particleData"] as? String,
                   let downloadURL = URL(string: particleURLString) else {
                 print("[EffectSync] particleData URL 없음: \(particleId)")
+                return
+            }
+
+            // 캐시 검증: 파일이 존재하고 URL이 일치하면 스킵
+            if isInCache(particleId: particleId) && isCacheValid(id: particleId, currentURL: particleURLString, type: .particle) {
                 return
             }
 
@@ -362,6 +356,14 @@ class EffectSyncManager {
                 try FileManager.default.removeItem(at: localURL)
             }
             try FileManager.default.moveItem(at: tempURL, to: localURL)
+
+            // 캐시 URL 저장
+            saveCacheURL(id: particleId, url: particleURLString, type: .particle)
+
+            // Lottie 애니메이션 캐시 클리어 (새 파일 로드를 위해)
+            await MainActor.run {
+                LottieAnimationCache.shared?.clearCache()
+            }
 
             print("[EffectSync] 파티클 다운로드 완료: \(particleId)")
 
@@ -394,5 +396,35 @@ class EffectSyncManager {
     /// 파티클이 번들에 있는지 확인 (무료 이펙트)
     private func isInBundle(particleId: String) -> Bool {
         return Bundle.main.path(forResource: particleId, ofType: "json") != nil
+    }
+
+    // MARK: - Cache URL Validation
+
+    private enum ItemType {
+        case sound
+        case particle
+    }
+
+    /// 캐시된 URL을 저장하는 UserDefaults 키
+    private func cacheURLKey(for id: String, type: ItemType) -> String {
+        switch type {
+        case .sound: return "cachedSoundURL_\(id)"
+        case .particle: return "cachedParticleURL_\(id)"
+        }
+    }
+
+    /// 캐시가 유효한지 확인 (파일 존재 + URL 일치)
+    private func isCacheValid(id: String, currentURL: String, type: ItemType) -> Bool {
+        let key = cacheURLKey(for: id, type: type)
+        guard let savedURL = UserDefaults.standard.string(forKey: key) else {
+            return false
+        }
+        return savedURL == currentURL
+    }
+
+    /// 캐시 URL 저장
+    private func saveCacheURL(id: String, url: String, type: ItemType) {
+        let key = cacheURLKey(for: id, type: type)
+        UserDefaults.standard.set(url, forKey: key)
     }
 }

--- a/Keychy/Keychy/Core/Firebase/StorageManager.swift
+++ b/Keychy/Keychy/Core/Firebase/StorageManager.swift
@@ -144,23 +144,39 @@ class StorageManager {
         let bodyImagesPath = "Keyrings/BodyImages/\(uid)"
         let customSoundsPath = "Keyrings/CustomSounds/\(uid)"
 
-        try await deleteFolder(path: bodyImagesPath)
-        try await deleteFolder(path: customSoundsPath)
+        // 두 폴더 병렬 삭제
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await self.deleteFolder(path: bodyImagesPath) }
+            group.addTask { try await self.deleteFolder(path: customSoundsPath) }
+            try await group.waitForAll()
+        }
     }
 
-    /// 폴더 삭제 (모든 하위 파일 삭제)
+    /// 폴더 삭제 (모든 하위 파일 병렬 삭제)
     private func deleteFolder(path: String) async throws {
         let storageRef = Storage.storage().reference().child(path)
 
         do {
             let result = try await storageRef.listAll()
 
-            for item in result.items {
-                try await item.delete()
+            // 파일들 병렬 삭제
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for item in result.items {
+                    group.addTask {
+                        try await item.delete()
+                    }
+                }
+                try await group.waitForAll()
             }
 
-            for prefix in result.prefixes {
-                try await deleteFolder(path: prefix.fullPath)
+            // 하위 폴더들 병렬 삭제
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for prefix in result.prefixes {
+                    group.addTask {
+                        try await self.deleteFolder(path: prefix.fullPath)
+                    }
+                }
+                try await group.waitForAll()
             }
 
             print("Storage 폴더 삭제 완료: \(path)")

--- a/Keychy/Keychy/Presentation/Intro/ViewModels/IntroViewModel+WelcomeKeyring.swift
+++ b/Keychy/Keychy/Presentation/Intro/ViewModels/IntroViewModel+WelcomeKeyring.swift
@@ -27,6 +27,9 @@ extension IntroViewModel {
         // 웰컴 카라비너를 사용자의 carabiners 필드에 추가
         try await addWelcomeCarabinerToUser(uid: uid)
 
+        // Confetti 파티클 캐시 검증 및 다운로드
+        await EffectSyncManager.shared.syncKeyringEffects(soundId: nil, particleId: "Confetti")
+
         Task.detached {
             await self.cacheWelcomeKeyring(
                 keyringId: keyringId,

--- a/Keychy/Keychy/Presentation/Intro/ViewModels/WelcomeKeyringViewModel.swift
+++ b/Keychy/Keychy/Presentation/Intro/ViewModels/WelcomeKeyringViewModel.swift
@@ -58,13 +58,21 @@ class WelcomeKeyringViewModel: KeyringViewModelProtocol {
     func fetchEffects() async {}
 
     func isOwned(soundId: String) -> Bool { false }
-    func isOwned(particleId: String) -> Bool { particleId == "Confetti" }
+    func isOwned(particleId: String) -> Bool { false }
 
-    func isInBundle(soundId: String) -> Bool { false }
-    func isInBundle(particleId: String) -> Bool { particleId == "Confetti" }
+    func isInBundle(soundId: String) -> Bool {
+        EffectManager.shared.isInBundle(soundId: soundId)
+    }
+    func isInBundle(particleId: String) -> Bool {
+        EffectManager.shared.isInBundle(particleId: particleId)
+    }
 
-    func isInCache(soundId: String) -> Bool { false }
-    func isInCache(particleId: String) -> Bool { particleId == "Confetti" }
+    func isInCache(soundId: String) -> Bool {
+        EffectManager.shared.isInCache(soundId: soundId)
+    }
+    func isInCache(particleId: String) -> Bool {
+        EffectManager.shared.isInCache(particleId: particleId)
+    }
 
     func downloadSound(_ sound: Sound) async {}
     func downloadParticle(_ particle: Particle) async {}

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/EffectSelectorView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/EffectSelectorView.swift
@@ -222,40 +222,23 @@ struct EffectSelectorView<VM: KeyringViewModelProtocol>: View {
                         // 장바구니에서 사운드 타입 제거 (무료로 교체)
                         cartItems.removeAll { $0.type == .sound }
                     }
-                    // 케이스 2: 구매 + 캐시 있음 → 바로 사용
-                    else if isOwned && isInCache {
-                        viewModel.updateSound(sound)
-                        // 장바구니에서 사운드 타입 제거 (보유템으로 교체)
-                        cartItems.removeAll { $0.type == .sound }
-                    }
-                    // 케이스 3: 구매 + 캐시 없음 → 재다운로드
-                    else if isOwned && !isInCache {
+                    // 케이스 2: 구매 → 캐시 검증 후 사용/재다운로드
+                    else if isOwned {
                         Task {
                             await viewModel.downloadSound(sound)
                         }
                         // 장바구니에서 사운드 타입 제거 (보유템으로 교체)
                         cartItems.removeAll { $0.type == .sound }
                     }
-                    // 케이스 4: 미구매 + 무료 + 캐시 있음 → 바로 사용
-                    else if !isOwned && sound.isFree && isInCache {
-                        viewModel.updateSound(sound)
-                        // 장바구니에서 사운드 타입 제거 (무료로 교체)
-                        cartItems.removeAll { $0.type == .sound }
-                    }
-                    // 케이스 5: 미구매 + 무료 + 캐시 없음 → 다운로드
-                    else if !isOwned && sound.isFree && !isInCache {
+                    // 케이스 3: 미구매 + 무료 → 캐시 검증 후 사용/재다운로드
+                    else if !isOwned && sound.isFree {
                         Task {
                             await viewModel.downloadSound(sound)
                         }
                         // 장바구니에서 사운드 타입 제거 (무료로 교체)
                         cartItems.removeAll { $0.type == .sound }
                     }
-                    // 케이스 6: 미구매 + 유료 + 캐시 있음 → 다운로드 + 장바구니 추가
-                    else if !isOwned && !sound.isFree && isInCache {
-                        viewModel.updateSound(sound)
-                        addSoundToCart(sound)
-                    }
-                    // 케이스 7: 미구매 + 유료 + 캐시 없음 → 다운로드 + 장바구니 추가
+                    // 케이스 4: 미구매 + 유료 → 캐시 검증 후 다운로드 + 장바구니 추가
                     else {
                         Task {
                             await viewModel.downloadSound(sound)
@@ -370,40 +353,23 @@ struct EffectSelectorView<VM: KeyringViewModelProtocol>: View {
                         // 장바구니에서 파티클 타입 제거 (무료로 교체)
                         cartItems.removeAll { $0.type == .particle }
                     }
-                    // 케이스 2: 구매 + 캐시 있음 → 바로 사용
-                    else if isOwned && isInCache {
-                        viewModel.updateParticle(particle)
-                        // 장바구니에서 파티클 타입 제거 (보유템으로 교체)
-                        cartItems.removeAll { $0.type == .particle }
-                    }
-                    // 케이스 3: 구매 + 캐시 없음 → 재다운로드
-                    else if isOwned && !isInCache {
+                    // 케이스 2: 구매 → 캐시 검증 후 사용/재다운로드
+                    else if isOwned {
                         Task {
                             await viewModel.downloadParticle(particle)
                         }
                         // 장바구니에서 파티클 타입 제거 (보유템으로 교체)
                         cartItems.removeAll { $0.type == .particle }
                     }
-                    // 케이스 4: 미구매 + 무료 + 캐시 있음 → 바로 사용
-                    else if !isOwned && particle.isFree && isInCache {
-                        viewModel.updateParticle(particle)
-                        // 장바구니에서 파티클 타입 제거 (무료로 교체)
-                        cartItems.removeAll { $0.type == .particle }
-                    }
-                    // 케이스 5: 미구매 + 무료 + 캐시 없음 → 다운로드
-                    else if !isOwned && particle.isFree && !isInCache {
+                    // 케이스 3: 미구매 + 무료 → 캐시 검증 후 사용/재다운로드
+                    else if !isOwned && particle.isFree {
                         Task {
                             await viewModel.downloadParticle(particle)
                         }
                         // 장바구니에서 파티클 타입 제거 (무료로 교체)
                         cartItems.removeAll { $0.type == .particle }
                     }
-                    // 케이스 6: 미구매 + 유료 + 캐시 있음 → 다운로드 + 장바구니 추가
-                    else if !isOwned && !particle.isFree && isInCache {
-                        viewModel.updateParticle(particle)
-                        addParticleToCart(particle)
-                    }
-                    // 케이스 7: 미구매 + 유료 + 캐시 없음 → 다운로드 + 장바구니 추가
+                    // 케이스 4: 미구매 + 유료 → 캐시 검증 후 다운로드 + 장바구니 추가
                     else {
                         Task {
                             await viewModel.downloadParticle(particle)


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### Firebase에서 이펙트(사운드/파티클) URL 변경 시 자동 재다운로드되도록 캐시 무효화 로직 추가

그동안은, 새로운 이펙트를 추가만했지 수정은 안했어서 이런 로직이 없었다.
그런데 이번 Confetti, CashRain 수정을 위해 개선이 필요했던 로직.


기본적으로 UserDefaults를 활용해서 
파이어스토어 데이터의 url을 비교한다. 
> 기존 사용자는 nil과 비교돼므로 자동으로 캐시를 다시 받게된다.

**변경된 부분**
- 웰컴키링 생성할 때. (Confetti를 쓰니까)
- 홈진입, 이때 사용자 모든 키링과 이펙트들을 로드하고 있음. (기존엔, 캐시바로 꺼내씀. 이젠 url을 검수 로직 생긴것)
- 만들기에서 이펙트 선택 시.

**아무튼 한마디로 이제 파베에서 이펙트 바꿀 수 있다는 뜻.**

### 회원탈퇴 시 Storage 파일 병렬 삭제로 속도 개선
> 매123우 느려서 보니 순차 -> 병렬로 리팩토링


### 홈 뭉치 이름 disabled 상태에서도 검정색 유지되도록 수정
> 최초가입하면 뭉치 1개인데, 이 경우 자동으로 disabled상태가 되었는데. 그러면 폰트컬러가 흐려보여서 
로직을 수정함.


## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #83 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
