### PR TITLE
perf: 뭉치 영상 생성 프레임 드랍 해결

### DIFF
--- a/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
@@ -86,6 +86,9 @@ class MultiKeyringScene: SKScene {
     var carabinerBackImageURL: String?  // 카라비너 뒷면 이미지 (hamburger 타입)
     var carabinerFrontImageURL: String?  // 카라비너 앞면 이미지 (hamburger 타입)
 
+    // MARK: - 영상 생성용 최적화 플래그
+    var disableShadows: Bool = false  // 그림자 비활성화 (영상 생성 시 성능 최적화)
+
     // MARK: - 카라비너 크기 및 위치 정보
     var carabinerId: String = ""  // 카라비너 ID (bundleKeyringScale용)
     var carabinerX: CGFloat = 0  // 카라비너 중심 X 좌표
@@ -243,6 +246,8 @@ class MultiKeyringScene: SKScene {
     ///   - offsetY: Y축 오프셋 (기본값 -8)
     ///   - blurRadius: Gaussian Blur 강도 (기본값 5.0)
     private func addShadowToNode(_ node: SKSpriteNode, offsetX: CGFloat = 8, offsetY: CGFloat = -8, blurRadius: CGFloat = 5.0) {
+        // 영상 생성 시 그림자 비활성화 (성능 최적화)
+        guard !disableShadows else { return }
         // 원본 노드를 복제해서 그림자로 사용
         guard let shadowNode = node.copy() as? SKSpriteNode else { return }
 

--- a/Keychy/Keychy/Core/Video/Bundle/BundleVideoGenerator+Particle.swift
+++ b/Keychy/Keychy/Core/Video/Bundle/BundleVideoGenerator+Particle.swift
@@ -14,13 +14,12 @@ import Lottie
 extension BundleVideoGenerator {
 
     /// 파티클 재생 정보
-    /// 현재 재생 중인 파티클을 렌더링하기 위해 필요한 모든 정보를 담고 있음
+    /// 시작 시점에 모든 프레임을 프리렌더링하여 재생 중에는 캐시된 텍스처만 사용
     struct ParticlePlaybackInfo {
-        let displaySprite: SKSpriteNode           // 화면에 표시되는 스프라이트
-        let startedAtFrame: Int                   // 파티클 시작 프레임
-        let particleId: String                    // 파티클 ID
-        let lottieRenderer: LottieAnimationView   // Lottie → 이미지 변환 렌더러
-        let animationData: LottieAnimation        // Lottie 메타데이터 (총 프레임 수 등)
+        let displaySprite: SKSpriteNode     // 화면에 표시되는 스프라이트
+        let startedAtFrame: Int             // 파티클 시작 프레임
+        let particleId: String              // 파티클 ID
+        let preRenderedTextures: [SKTexture] // 프리렌더링된 텍스처 배열
     }
 
     /// 파티클 업데이트
@@ -43,23 +42,33 @@ extension BundleVideoGenerator {
         particleIndicesToRemove.forEach { playingParticles.removeValue(forKey: $0) }
     }
 
-    /// 파티클 시작
+    /// 파티클 시작 (모든 프레임을 프리렌더링)
     private func startParticle(for keyringIndex: Int, particleId: String, at frameIndex: Int, scene: MultiKeyringScene) {
         guard let animation = findParticleAnimation(particleId: particleId) else {
             return
         }
 
+        // Lottie 뷰 설정
         let config = LottieConfiguration(renderingEngine: .mainThread)
         let lottieView = LottieAnimationView(animation: animation, configuration: config)
         lottieView.frame = CGRect(origin: .zero, size: CGSize(width: scene.size.width, height: scene.size.height))
         lottieView.contentMode = .scaleAspectFit
         lottieView.backgroundBehavior = .pauseAndRestore
 
+        // 모든 프레임을 프리렌더링
+        let textures = preRenderAllFrames(lottieView: lottieView, animation: animation)
+
+        // 스프라이트 생성
         let sprite = SKSpriteNode()
         sprite.size = CGSize(width: scene.size.width, height: scene.size.height)
         sprite.position = CGPoint(x: scene.size.width / 2, y: scene.size.height / 2)
         sprite.zPosition = 100
         sprite.alpha = 1.0
+
+        // 첫 프레임 텍스처 설정
+        if let firstTexture = textures.first {
+            sprite.texture = firstTexture
+        }
 
         scene.addChild(sprite)
 
@@ -67,12 +76,35 @@ extension BundleVideoGenerator {
             displaySprite: sprite,
             startedAtFrame: frameIndex,
             particleId: particleId,
-            lottieRenderer: lottieView,
-            animationData: animation
+            preRenderedTextures: textures
         )
     }
 
-    /// 파티클 렌더링
+    /// Lottie 애니메이션의 모든 프레임을 SKTexture로 프리렌더링
+    private func preRenderAllFrames(lottieView: LottieAnimationView, animation: LottieAnimation) -> [SKTexture] {
+        let totalFrames = Int(animation.endFrame - animation.startFrame)
+        var textures: [SKTexture] = []
+        textures.reserveCapacity(totalFrames)
+
+        // UIGraphicsImageRenderer를 한 번만 생성 (재사용)
+        let imageRenderer = UIGraphicsImageRenderer(bounds: lottieView.bounds)
+
+        for frameOffset in 0..<totalFrames {
+            let targetFrame = animation.startFrame + CGFloat(frameOffset)
+            lottieView.currentFrame = AnimationFrameTime(targetFrame)
+            lottieView.setNeedsDisplay()
+            lottieView.layer.displayIfNeeded()
+
+            let image = imageRenderer.image { context in
+                lottieView.layer.render(in: context.cgContext)
+            }
+            textures.append(SKTexture(image: image))
+        }
+
+        return textures
+    }
+
+    /// 파티클 렌더링 (프리렌더링된 텍스처 사용)
     private func updateActiveParticle(for keyringIndex: Int, at frameIndex: Int, scene: MultiKeyringScene) -> Bool {
         guard let particleInfo = playingParticles[keyringIndex] else {
             return false
@@ -80,23 +112,15 @@ extension BundleVideoGenerator {
 
         let sprite = particleInfo.displaySprite
         let offset = frameIndex - particleInfo.startedAtFrame
-        let targetFrame = particleInfo.animationData.startFrame + CGFloat(offset)
 
-        if targetFrame >= particleInfo.animationData.endFrame {
+        // 애니메이션 종료 체크
+        if offset >= particleInfo.preRenderedTextures.count {
             sprite.removeFromParent()
             return true
         }
 
-        particleInfo.lottieRenderer.currentFrame = AnimationFrameTime(targetFrame)
-        particleInfo.lottieRenderer.setNeedsDisplay()
-        particleInfo.lottieRenderer.layer.displayIfNeeded()
-
-        let imageRenderer = UIGraphicsImageRenderer(bounds: particleInfo.lottieRenderer.bounds)
-        let image = imageRenderer.image { context in
-            particleInfo.lottieRenderer.layer.render(in: context.cgContext)
-        }
-
-        sprite.texture = SKTexture(image: image)
+        // 프리렌더링된 텍스처 사용 (매우 빠름)
+        sprite.texture = particleInfo.preRenderedTextures[offset]
 
         return false
     }

--- a/Keychy/Keychy/Core/Video/Bundle/BundleVideoGenerator+Setup.swift
+++ b/Keychy/Keychy/Core/Video/Bundle/BundleVideoGenerator+Setup.swift
@@ -62,6 +62,7 @@ extension BundleVideoGenerator {
         scene.currentCarabinerType = carabinerType
         scene.scaleMode = .aspectFill
         scene.size = CGSize(width: sceneWidth, height: sceneHeight)
+        scene.disableShadows = true  // 영상 생성 시 그림자 비활성화 (성능 최적화)
 
         if let bgImage = backgroundImage {
             let backgroundNode = SKSpriteNode(texture: SKTexture(image: bgImage))


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 뭉치 영상 생성 시 후반부로 갈수록 심해지던 프레임 드랍 현상 해결
특히 스윙 이후 급격히 느려지던 문제

### 결론먼저, 핵심 원인은 "그림자 효과" (CIGaussianBlur)

### 1. 그림자 비활성화 (핵심 원인)
  **Before**
  매 프레임마다 Ring, Chain(5~6개), Body, Carabiner 각각에 `CIGaussianBlur` 그림자 렌더링!!!
> 무거운 blur 연산

  **After**: 영상 생성 시 `disableShadows = true` 플래그로 그림자 스킵


아래 내용들 먼저, 수행을 해봤는데 (키링 영상 추출과 최대한 다시 비슷하게)
변화가 미미해서, 그림자를 제거해봤는데 그냥 바로 좋아짐.
사실 영상에선 그림자가 불필요하기도하고, 그냥 뷰의 shadow가 아닌 로직이다보니 
영상으로 렌더링하기에는 너무 무거움

---

  #### 2. 파티클 프리렌더링
  **Before**
파티클 재생 중 매 프레임마다 Lottie → UIImage → SKTexture 변환
> CPU에서 실시간 렌더링 (느림)

  **After**
파티클 시작 시점에 모든 프레임을 미리 렌더링해서 배열에 저장
> 재생 중에는 배열에서 꺼내쓰기만 함 (빠름)

  #### 3. UIGraphicsImageRenderer 재사용
  **Before**
  매 프레임마다 새로운 renderer 생성

  **After**
하나의 renderer를 만들어서 모든 프레임에 재사용
> 메모리 할당/해제 오버헤드 감소


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

https://github.com/user-attachments/assets/ec4ae3fa-6f7a-449f-8089-c0e826820a2d



## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #85 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
