### PR TITLE
fix: 템플릿 프리뷰 이미지 왼쪽 치우침 등 4가지 QA

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -3235,7 +3235,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3284,7 +3284,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3324,7 +3324,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app.WidgetKeychy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3367,7 +3367,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app.WidgetKeychy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel.swift
+++ b/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel.swift
@@ -60,6 +60,7 @@ class BundleViewModel {
     // MARK: - 뭉치 캡쳐 이미지
 
     var bundleCapturedImage: Data?
+    var bundleWidgetImage: Data?
 
     // MARK: - 현재 선택된 뭉치
 

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Capture.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Capture.swift
@@ -104,7 +104,7 @@ extension BundleCreateView {
             carabinerFrontURL = nil
         }
 
-        // 씬 캡처
+        // 1. 배경 포함 캡처 (앱용)
         if let pngData = await MultiKeyringCaptureScene.captureBundleImage(
             keyringDataList: keyringDataList,
             backgroundImageURL: background.backgroundImage,
@@ -119,6 +119,23 @@ extension BundleCreateView {
             await MainActor.run {
                 bundleVM.bundleCapturedImage = pngData
             }
+        }
+
+        // 2. 배경 없이 캡처 (위젯용 - 투명 여백 제거)
+        let widgetData = await MultiKeyringCaptureScene.captureBundleImage(
+            keyringDataList: keyringDataList,
+            backgroundImageURL: nil,
+            carabinerBackImageURL: carabinerBackURL,
+            carabinerFrontImageURL: carabinerFrontURL,
+            carabinerType: carabinerType,
+            carabinerId: carabiner.id ?? "",
+            carabinerX: carabiner.carabinerX,
+            carabinerY: carabiner.carabinerY,
+            carabinerWidth: carabiner.carabinerWidth,
+            trimTransparentEdges: true
+        )
+        await MainActor.run {
+            bundleVM.bundleWidgetImage = widgetData
         }
 
         // 캡처 완료 후 다음 화면으로 이동

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Initialization.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Initialization.swift
@@ -6,14 +6,24 @@
 //
 
 import SwiftUI
+import Nuke
 
 // MARK: - 데이터 초기화
 extension BundleCreateView {
 
     /// 초기 데이터 로딩
     func initializeData() async {
-        // 사용자가 소유한 배경과 카라비너 데이터를 가져옴
         await loadUserOwnedItems()
+        // 시트 이미지 프리페칭 (백그라운드에서 Nuke 캐시에 미리 로드)
+        prefetchSheetImages()
+    }
+
+    /// 배경/카라비너 썸네일을 Nuke 캐시에 미리 로드
+    private func prefetchSheetImages() {
+        let bgURLs = bundleVM.backgroundViewData.compactMap { URL(string: $0.background.backgroundImage) }
+        let cbURLs = bundleVM.carabinerViewData.compactMap { URL(string: $0.carabiner.carabinerImage[0]) }
+        let prefetcher = ImagePrefetcher()
+        prefetcher.startPrefetching(with: bgURLs + cbURLs)
     }
 
     /// 화면이 다시 나타날 때 데이터 새로고침

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
@@ -53,42 +53,46 @@ extension BundleCreateView {
     var sheetContent: some View {
         ZStack(alignment: .bottom) {
             Color.clear
-            
-            if showItemSheet {
-                // 시트가 있을 때: 셀렉터 + 시트가 함께 움직임
-                VStack(spacing: 0) {
-                    BundleSheetToggleButtons(
-                        showItemSheet: $showItemSheet,
-                        isBackgroundMode: $isBackgroundMode
-                    )
-                    .padding(.bottom, 10)
-                    
-                    DraggableSheet(
-                        sheetHeight: $sheetHeight,
-                        header: BundleSheetFilterBar(viewModel: bundleVM),
-                        content: itemSheetContent,
-                        onDismiss: {
-                            showItemSheet = false
-                        }
-                    )
+
+            // 시트 레이어 (항상 존재, 오프셋으로 숨김 → 즉시 반응)
+            DraggableSheet(
+                sheetHeight: $sheetHeight,
+                header: BundleSheetFilterBar(viewModel: bundleVM),
+                content: itemSheetContent,
+                onDismiss: {
+                    showItemSheet = false
                 }
-                .transition(.move(edge: .bottom))
-            } else {
-                // 시트가 없을 때: 셀렉터만 하단에 고정
+            )
+            .offset(y: showItemSheet ? 0 : sheetHeight)
+            .allowsHitTesting(showItemSheet)
+
+            // 버튼 레이어 (matchedGeometryEffect로 위치만 보간)
+            if showItemSheet {
                 BundleSheetToggleButtons(
                     showItemSheet: $showItemSheet,
                     isBackgroundMode: $isBackgroundMode
                 )
+                .matchedGeometryEffect(id: "toggleButtons", in: sheetButtonNamespace)
+                .padding(.bottom, sheetHeight + 10)
+            } else {
+                BundleSheetToggleButtons(
+                    showItemSheet: $showItemSheet,
+                    isBackgroundMode: $isBackgroundMode
+                )
+                .matchedGeometryEffect(id: "toggleButtons", in: sheetButtonNamespace)
                 .padding(.bottom, 50)
-                .transition(.identity)
             }
         }
-        .animation(.easeInOut(duration: 0.25), value: showItemSheet)
+        .animation(.easeOut(duration: 0.2), value: showItemSheet)
+        .onChange(of: showItemSheet) { _, isShowing in
+            if isShowing {
+                sheetHeight = UIScreen.main.bounds.height * 0.4
+            }
+        }
     }
     
-    @ViewBuilder
     var itemSheetContent: some View {
-        if isBackgroundMode {
+        ZStack(alignment: .top) {
             SelectBackgroundSheet(
                 viewModel: bundleVM,
                 selectedBG: bundleVM.newSelectedBackground,
@@ -96,7 +100,9 @@ extension BundleCreateView {
                     bundleVM.newSelectedBackground = bg
                 }
             )
-        } else {
+            .opacity(isBackgroundMode ? 1 : 0)
+            .allowsHitTesting(isBackgroundMode)
+
             SelectCarabinerSheet(
                 viewModel: bundleVM,
                 selectedCarabiner: bundleVM.newSelectedCarabiner,
@@ -105,6 +111,8 @@ extension BundleCreateView {
                     bundleVM.newSelectedCarabiner = carabiner
                 }
             )
+            .opacity(isBackgroundMode ? 0 : 1)
+            .allowsHitTesting(!isBackgroundMode)
         }
     }
     

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
@@ -29,7 +29,15 @@ extension BundleCreateView {
                     isSelected: selectedPosition == index,
                     action: {
                         selectedPosition = index
-                        showKeyringSheet = true
+                        if showItemSheet {
+                            // 배경/카라비너 시트 닫기 → 닫힌 후 키링 시트 표시
+                            showItemSheet = false
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                showKeyringSheet = true
+                            }
+                        } else {
+                            showKeyringSheet = true
+                        }
                     }
                 )
                 .position(x: viewX, y: viewY)

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
@@ -97,6 +97,9 @@ struct BundleCreateView<Route: BundleRoute>: View {
                     keyringButtons(carabiner: cb.carabiner)
                 }
                 .blur(radius: showPurchaseSuccessAlert || isCapturing ? 10 : 0)
+                .onTapGesture {
+                    if showItemSheet { showItemSheet = false }
+                }
 
                 // 하단 셀렉터 + 시트
                 sheetContent

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
@@ -24,12 +24,13 @@ struct BundleCreateView<Route: BundleRoute>: View {
     @Bindable var bundleVM: BundleViewModel
 
     // 시트 활성화 상태
+    @Namespace var sheetButtonNamespace
     @State var showItemSheet: Bool = false
     @State var isBackgroundMode: Bool = true  // true: 배경, false: 카라비너
     @State var showKeyringSheet: Bool = false
 
-    // 시트 높이
-    @State var sheetHeight: CGFloat = 360
+    // 시트 높이 (DraggableSheet.onAppear에서 mediumHeight로 갱신됨)
+    @State var sheetHeight: CGFloat = UIScreen.main.bounds.height * 0.4
 
     // 키링 선택 상태
     @State var selectedKeyrings: [Int: Keyring] = [:]

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleNameInputView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleNameInputView.swift
@@ -223,7 +223,8 @@ extension BundleNameInputView {
                 // Firebase 저장 성공 후 ViewModel의 이미지를 캐시에 저장
                 bundleVM.saveBundleImageToCache(
                     bundleId: bundleId,
-                    bundleName: bundleNameToSave
+                    bundleName: bundleNameToSave,
+                    widgetImageData: bundleVM.bundleWidgetImage
                 )
 
                 isUploading = false

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Initialization.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Initialization.swift
@@ -7,15 +7,26 @@
 
 import SwiftUI
 import FirebaseFirestore
+import Nuke
 
 extension BundleEditView {
     func initializeData() async {
         resetSceneState()
-        
+
         await loadUserKeyring()
-        
+
         await loadBackgroundAndCarabiner()
-        
+
+        // 시트 이미지 프리페칭 (백그라운드에서 Nuke 캐시에 미리 로드)
+        prefetchSheetImages()
+    }
+
+    /// 배경/카라비너 썸네일을 Nuke 캐시에 미리 로드
+    private func prefetchSheetImages() {
+        let bgURLs = bundleVM.backgroundViewData.compactMap { URL(string: $0.background.backgroundImage) }
+        let cbURLs = bundleVM.carabinerViewData.compactMap { URL(string: $0.carabiner.carabinerImage[0]) }
+        let prefetcher = ImagePrefetcher()
+        prefetcher.startPrefetching(with: bgURLs + cbURLs)
     }
     
     func resetSceneState() {

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+SelectSheet.swift
@@ -12,41 +12,45 @@ extension BundleEditView {
         ZStack(alignment: .bottom) {
             Color.clear
 
-            if showItemSheet {
-                // 시트가 있을 때: 셀렉터 + 시트가 함께 움직임
-                VStack(spacing: 0) {
-                    BundleSheetToggleButtons(
-                        showItemSheet: $showItemSheet,
-                        isBackgroundMode: $isBackgroundMode
-                    )
-                    .padding(.bottom, 10)
-
-                    DraggableSheet(
-                        sheetHeight: $sheetHeight,
-                        header: BundleSheetFilterBar(viewModel: bundleVM),
-                        content: itemSheetContent,
-                        onDismiss: {
-                            showItemSheet = false
-                        }
-                    )
+            // 시트 레이어 (항상 존재, 오프셋으로 숨김 → 즉시 반응)
+            DraggableSheet(
+                sheetHeight: $sheetHeight,
+                header: BundleSheetFilterBar(viewModel: bundleVM),
+                content: itemSheetContent,
+                onDismiss: {
+                    showItemSheet = false
                 }
-                .transition(.move(edge: .bottom))
-            } else {
-                // 시트가 없을 때: 셀렉터만 하단에 고정
+            )
+            .offset(y: showItemSheet ? 0 : sheetHeight)
+            .allowsHitTesting(showItemSheet)
+
+            // 버튼 레이어 (matchedGeometryEffect로 위치만 보간)
+            if showItemSheet {
                 BundleSheetToggleButtons(
                     showItemSheet: $showItemSheet,
                     isBackgroundMode: $isBackgroundMode
                 )
+                .matchedGeometryEffect(id: "toggleButtons", in: sheetButtonNamespace)
+                .padding(.bottom, sheetHeight + 10)
+            } else {
+                BundleSheetToggleButtons(
+                    showItemSheet: $showItemSheet,
+                    isBackgroundMode: $isBackgroundMode
+                )
+                .matchedGeometryEffect(id: "toggleButtons", in: sheetButtonNamespace)
                 .padding(.bottom, 50)
-                .transition(.identity)
             }
         }
-        .animation(.easeInOut(duration: 0.25), value: showItemSheet)
+        .animation(.easeOut(duration: 0.2), value: showItemSheet)
+        .onChange(of: showItemSheet) { _, isShowing in
+            if isShowing {
+                sheetHeight = UIScreen.main.bounds.height * 0.4
+            }
+        }
     }
 
-    @ViewBuilder
     private var itemSheetContent: some View {
-        if isBackgroundMode {
+        ZStack(alignment: .top) {
             SelectBackgroundSheet(
                 viewModel: bundleVM,
                 selectedBG: bundleVM.newSelectedBackground,
@@ -54,7 +58,9 @@ extension BundleEditView {
                     bundleVM.newSelectedBackground = bg
                 }
             )
-        } else {
+            .opacity(isBackgroundMode ? 1 : 0)
+            .allowsHitTesting(isBackgroundMode)
+
             SelectCarabinerSheet(
                 viewModel: bundleVM,
                 selectedCarabiner: bundleVM.newSelectedCarabiner,
@@ -63,6 +69,8 @@ extension BundleEditView {
                     showChangeCarabinerAlert = true
                 }
             )
+            .opacity(isBackgroundMode ? 0 : 1)
+            .allowsHitTesting(!isBackgroundMode)
         }
     }
     

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
@@ -25,6 +25,7 @@ struct BundleEditView<Route: BundleRoute>: View {
     @State var isCapturing: Bool = false
     
     // MARK: - Sheet
+    @Namespace var sheetButtonNamespace
     @State var showItemSheet: Bool = false
     @State var isBackgroundMode: Bool = true  // true: 배경, false: 카라비너
     @State var showPurchaseSheet = false
@@ -52,7 +53,8 @@ struct BundleEditView<Route: BundleRoute>: View {
     ]
     
     // 시트 높이 (화면의 약 43%에 해당)
-    @State var sheetHeight: CGFloat = 360
+    // 시트 높이 (DraggableSheet.onAppear에서 mediumHeight로 갱신됨)
+    @State var sheetHeight: CGFloat = UIScreen.main.bounds.height * 0.4
     @State var purchasesSuccessScale: CGFloat = 0.3
     @State var purchaseFailScale: CGFloat = 0.3
     let sheetHeightRatio: CGFloat = 0.43

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
@@ -171,6 +171,9 @@ struct BundleEditView<Route: BundleRoute>: View {
             // navigationBar
             customNavigationBar
         }
+        .onTapGesture {
+            if showItemSheet { showItemSheet = false }
+        }
     }
     
     // MARK: - 키링 편집 씬 뷰
@@ -228,8 +231,18 @@ struct BundleEditView<Route: BundleRoute>: View {
                         isSelected: selectedPosition == index,
                         action: {
                             selectedPosition = index
-                            withAnimation(.easeInOut) {
-                                showSelectKeyringSheet = true
+                            if showItemSheet {
+                                // 배경/카라비너 시트 닫기 → 닫힌 후 키링 시트 표시
+                                showItemSheet = false
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                    withAnimation(.easeInOut) {
+                                        showSelectKeyringSheet = true
+                                    }
+                                }
+                            } else {
+                                withAnimation(.easeInOut) {
+                                    showSelectKeyringSheet = true
+                                }
                             }
                         }
                     )

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
@@ -201,7 +201,7 @@ extension TemplatePreviewBody {
                 LoadingAlert(type: .short40, message: nil)
             }
         }
-        .frame(maxHeight: 500)
+        .frame(maxWidth: .infinity, maxHeight: 500)
     }
 
     /// 템플릿 정보 섹션

--- a/Keychy/Keychy/Presentation/Workshop/Views/Keyring/WorkshopTemplateSelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Views/Keyring/WorkshopTemplateSelectSheet.swift
@@ -192,7 +192,7 @@ struct WorkshopTemplateSelectSheet: View {
 
                             Spacer()
 
-                            // 보유 뱃지 (오른쪽 상단) - 보유 또는 무료일 때
+                            // 보유 뱃지 (오른쪽 상단) - 유료 + 보유일 때만
                             Text("보유")
                                 .typography(.suit13M)
                                 .foregroundStyle(.white100)
@@ -202,7 +202,7 @@ struct WorkshopTemplateSelectSheet: View {
                                     RoundedRectangle(cornerRadius: 20)
                                         .fill(.black60)
                                 )
-                                .opacity(isOwned || template.isFree ? 1 : 0)
+                                .opacity(isOwned && !template.isFree ? 1 : 0)
                         }
                         .padding(.top, 6)
                         .padding(.horizontal, 7)

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -5910,9 +5910,9 @@
       "peer": true
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

앞으론 문법도 조금 PR에 녹여서 정리해보겠습니다

### 1. fix: 템플릿 프리뷰 이미지 왼쪽 치우침 수정

  **원인: 부모 VStack이 .leading 정렬이라 이미지도 왼쪽으로 밀림**

  `.frame(maxWidth: .infinity, maxHeight: 500)` // 가로 전체 채우기

>  maxWidth: .infinity — 부모 정렬과 무관하게 가용 너비를 꽉 채움

### 2. feat: 키링 +버튼 → 배경/카라비너 시트 자동 닫힘

  **원인: 키링 시트와 아이템 시트가 공존 가능해서 2중 시트 발생**

```swift
showItemSheet = false
DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { showKeyringSheet = true }
```

> 닫힘 애니메이션(0.25s) 완료 후 키링 시트를 여는 타이밍 처리

### 3. perf: 배경/카라비너 시트 렌더링 최적화 (이건 없던 이슈인데, 추가 개선)

**원인: if 조건부 렌더링은 매번 뷰를 새로 만들어서 느림 + 탭 전환마다 로딩 깜빡임**

그리고, `matchedGeometryEffect`를 활용해서 보다 부드럽게 탭이 올라가고 내려오도록 개선했습니다.

// 시트: 항상 존재, 위치만 이동
`DraggableSheet(...).offset(y: showItemSheet ? 0 : sheetHeight)`

// 탭 전환: 두 시트 항상 유지, 투명도만 전환
`SelectBackgroundSheet(...).opacity(isBackgroundMode ? 1 : 0)`

> offset 방식 — 뷰를 숨기되 파괴하지 않아서 재생성 비용 없음
#### matchedGeometryEffect
서로 다른 위치에 있는 두 뷰를 "같은 뷰"로 인식시켜서, 
SwiftUI가 자동으로 위치/크기 전환 애니메이션을 만들어주는 건데 
자료 한 번 가볍게 찾아보시면 좋을듯합니다!

### 4. perf: 시트 썸네일 프리패칭

**원인: 시트를 처음 열 때 이미지 다운로드가 시작돼서 최초 1회 렉 발생**

`ImagePrefetcher().startPrefetching(with: bgURLs + cbURLs)`

> 뷰 진입 시점에 미리 이미지를 캐시에 로드 (Nuke 라이브러리)

### 5. fix: 무료 템플릿에 "보유" 태그 표시되던 문제

**원인: 조건이 ||(또는)라서 무료 아이템도 뱃지가 보임**

```swift
// 수정 전: 
isOwned || template.isFree  (무료면 무조건 보임)


// 수정 후:
.opacity(isOwned && !template.isFree ? 1 : 0)  // 유료 + 보유일 때만
```

> || → && + !isFree 로 조건 교체

### 6. fix: 뭉치 생성 시 위젯 이미지 누락

**원인: 뭉치 "편집" 시에만 위젯용 이미지를 만들고, "생성" 시에는 안 만들고 있었음**

// 배경 없이 캡처 → 위젯용 투명 이미지
`captureBundleImage(backgroundImageURL: nil, trimTransparentEdges: true)`

> 생성 흐름에도 위젯 전용 캡처(배경 제거 + 여백 트림)를 추가
> 근데 왜, 캡처가 안된경우에 풀스크린 캐시 이미지가 위젯으로 나왔냐면 그런 조건이 걸려있음. 
> 위젯 캐시 이미지 없으면, 풀스크린 캐시 이미지로 들어가도록.


### 7. fix: npm 보안 이슈 해결 

이건 너무 자주뜨네 ㄱ- 
암튼 `npm audit fix` 했고 해결완.


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
<img width="250" alt="프리뷰 수정전" src="https://github.com/user-attachments/assets/0ff4f997-2141-4fda-b2ee-6148e2e5af48" />  

<img width="250" alt="프리뷰 수정후" src="https://github.com/user-attachments/assets/8ec76544-d65e-44cb-b292-7c29989be571" />


> 프리뷰 위치 조정 전/후, 이렇게 보면 체감 안될 수도 있지만, 실제로 굉장히 체감됨.

<img width="250" alt="템플릿선택시트 - 무료태그 제거" src="https://github.com/user-attachments/assets/17e14992-11ea-44b7-a12d-df4b6fee60ad" />

> 템플릿 선택 시트 - 무료템 '보유태그' 제거


<img width="250" alt="스크린샷, 2026-02-15 02 23 04" src="https://github.com/user-attachments/assets/52ad674c-5e5d-4b83-b448-b5225f1cd19d" />

> 뭉치 위젯 버그 해결 - 뭉치 만들기 하고 바로 나와서 위젯 설정해보았음.
돌아보면, 굉장히 치명적인 버그였음.


https://github.com/user-attachments/assets/33bc414d-f04b-4496-981d-9a963e881b2f

https://github.com/user-attachments/assets/81e2fa24-30cb-44a8-8551-069e63e011ec


> 체감 되나요? 이쪽 UX 개편
첫번째 영상 -> 배경/카라비너 셀렉터 누르면, 셀렉터가 잠시 사라졌다가 등장함.
두번째 영상 -> 그 외, 더 부드러워짐 + 아이템 로딩도 셀렉터 바꿀때마다 뷰를 재생성했는데 아이템 이미지 유지함 이제.


## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #105 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료


> 테스트플라이트로 테스트 받고 배포 진행 예정