### PR TITLE
fix: 홈 탭 뭉치 로딩 중 탭 전환 복귀 시 무한로딩 해결

### DIFF
--- a/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
@@ -65,7 +65,7 @@ class MultiKeyringScene: SKScene {
     private var totalKeyringsToLoad = 0  // 로드해야 할 총 키링 수
     private var loadedKeyringsCount = 0  // 완료(성공/실패)된 키링 수
     private var loadedKeyringsSuccessCount = 0  // 성공적으로 로드된 키링 수
-    private var isPhysicsEnabled = false  // 물리 엔진 활성화 여부
+    private(set) var isPhysicsEnabled = false  // 물리 엔진 활성화 여부
 
     // MARK: - 카라비너 로드 상태
     private var carabinerBackReady = false

--- a/Keychy/Keychy/Core/KeyringBundle/View/MultiKeyringSceneView.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/View/MultiKeyringSceneView.swift
@@ -96,6 +96,9 @@ struct MultiKeyringSceneView: View {
                 loadBackgroundImage()
                 loadCarabinerLottieAspectRatio()
                 setupScene()
+            } else {
+                // 탭 전환 복귀 시: onDisappear에서 nil 처리된 콜백 복원
+                restoreCallbacksIfNeeded()
             }
         }
         .onChange(of: backgroundImageURL) { _, _ in
@@ -259,6 +262,24 @@ extension MultiKeyringSceneView {
                     // 배경 이미지 로드 완료 콜백 호출
                     onBackgroundLoaded?()
                 }
+            }
+        }
+    }
+
+    /// 탭 전환 복귀 시 onDisappear에서 nil 처리된 콜백 복원
+    /// onDisappear에서 scene?.onSetupComplete = nil로 설정되므로,
+    /// 탭 복귀 시 씬이 아직 로딩 중이면 콜백을 재설정하고
+    /// 이미 완료됐으면 즉시 콜백을 호출
+    private func restoreCallbacksIfNeeded() {
+        guard let scene else { return }
+
+        if scene.isPhysicsEnabled {
+            // 씬 로딩이 이미 완료된 상태 → 직접 콜백 호출
+            onAllKeyringsReady?()
+        } else {
+            // 씬이 아직 로딩 중 → 콜백 재설정
+            scene.onSetupComplete = {
+                onAllKeyringsReady?()
             }
         }
     }


### PR DESCRIPTION
## 문제

**홈 탭에서 뭉치 로딩이 완료되기 전에 다른 탭으로 이동했다가 다시 홈으로 돌아오면, 
**로딩이 영원히 끝나지 않는 버그**가 발생했습니다.**

## 간단하게 비유로 이해해보자
1. 택배 기사(씬)가 집(홈 탭)에 배달 완료하면 **초인종(onSetupComplete 콜백)** 을 눌러 알려줍니다.
2. 그런데? 외출(탭 전환) 시 **초인종 전원을 꺼버리고(onDisappear → nil)**, 
돌아와서도 **다시 켜지 않아서** 택배가 도착했는데도 모르는 상태가 됩니다.

> **수정한 부분 => 귀가(onAppear) 시 초인종 전원을 다시 켜고, 이미 택배가 와 있으면 바로 확인합니다.**

## 원인

무한로딩에 걸리는 단계를 설명해보면,

### 1. 데이터 로딩은 계속 진행됨
홈에서 실행된 `.task`가 탭이 전환되어서 취소되어도 
`loadMainBundle()`은 **cooperative cancellation**이라 **끝까지 실행**됩니다.

**cooperative cancellation**을 간단히 이해해보면 Swift Task의 취소 동작 방식입니다.
> Task는 취소해도 강제로 멈추지 않고, "취소됐다"는 표시만 남깁니다.
> 실제로 멈추려면 함수 내부에서 `Task.isCancelled`를 직접 확인해야 합니다!

`loadMainBundle()`은 이 확인 코드가 없기 때문에, 
탭을 전환해도 백그라운드에서 **끝까지 실행**됩니다.

결론적으로,
**데이터도 로드되고, 씬도 로드되지만, "다 됐어!"라고 알려주는 콜백이 사라져서 화면이 영원히 로딩 상태에 머무르는 것!**

왜 콜백이 사라지는가는 아래에서 이어집니다.


### 2. 콜백이 사라짐
`MultiKeyringSceneView.onDisappear`에서 `.id()` 변경 대응용으로 `scene?.onSetupComplete = nil` 처리가 있습니다.
탭 전환 시에도 이 코드가 실행되어 **씬 완료 콜백이 사라집니다.**

### 3. 복귀해도 복원 안 됨
탭 복귀 시 `onAppear`에서 `scene != nil`이므로 씬을 재생성하지 않습니다.
씬은 이미 로딩을 완료했지만 콜백이 없으므로 `isSceneReady = true`가 **영원히 호출되지 않습니다.**

## 해결

### `MultiKeyringSceneView.swift`
`onAppear`에서 **탭 복귀 시 콜백 복원 로직** 추가:

  ```swift
  .onAppear {
      if scene == nil {
          // 최초 진입: 씬 생성
          setupScene()
      } else {
          // 탭 복귀: 콜백 복원
          restoreCallbacksIfNeeded()
      }
  }
```

```swift
private func restoreCallbacksIfNeeded() {
    guard let scene else { return }

    if scene.isPhysicsEnabled {
        // 씬 로딩 완료 상태 → 즉시 콜백 호출
        onAllKeyringsReady?()
    } else {
        // 씬 아직 로딩 중 → 콜백 재설정
        scene.onSetupComplete = {
            onAllKeyringsReady?()
        }
    }
}
```

> isPhysicsEnabled를 private(set)으로 변경하여 씬 완료 상태를 외부에서 확인 가능하게 함.

### 테스트 해본거

- 최초 접속 → 로딩 중 빠르게 탭 전환 → 복귀 시 정상 표시
- 로딩 중 탭 여러 번 왔다갔다 → 최종 복귀 시 정상 표시
- 뭉치 변경 → 로딩 중 탭 이동 → 복귀 시 새 뭉치 정상 표시
- 빈 뭉치(키링 0개) → 탭 이동 → 복귀 시 무한로딩 없음
- 마이페이지 push → 뒤로가기 → 기존 동작 정상

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #110 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
