### PR TITLE
fix: 오랜만에 앱 접속 시 Lottie 배경/카라비너 미표시 문제 수정

### DIFF
--- a/Keychy/Keychy/Core/FileManagers/LottieItemManager.swift
+++ b/Keychy/Keychy/Core/FileManagers/LottieItemManager.swift
@@ -146,15 +146,22 @@ class LottieItemManager {
             }
         }
 
-        // 완료 대기
-        await withCheckedContinuation { continuation in
+        // 완료 대기 (성공/실패 구분)
+        let success = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             downloadTask.observe(.success) { _ in
-                continuation.resume()
+                continuation.resume(returning: true)
             }
-            downloadTask.observe(.failure) { _ in
-                continuation.resume()
+            downloadTask.observe(.failure) { snapshot in
+                print("[LottieItemManager] 다운로드 실패 (\(type.rawValue)/\(id)): \(snapshot.error?.localizedDescription ?? "알 수 없는 에러")")
+                continuation.resume(returning: false)
             }
         }
+
+        downloadingItemIds.remove(downloadKey)
+        downloadProgress.removeValue(forKey: downloadKey)
+
+        // 실패 시 캐시 저장하지 않고 조기 종료
+        guard success else { return }
 
         // 파일 쓰기 완료 확인
         try? await Task.sleep(nanoseconds: 100_000_000)
@@ -164,14 +171,11 @@ class LottieItemManager {
             attempts += 1
         }
 
-        // 캐시 URL 저장 (다음 검증용)
+        // 캐시 URL 저장 (성공 시에만 — 다음 검증용)
         saveCacheURL(id: id, url: remoteURL, type: type)
 
         // 해당 에셋의 인메모리 캐시만 무효화 (전체 캐시 삭제 X)
         LottieItemView.invalidateCache(assetId: id, directory: type.rawValue)
-
-        downloadingItemIds.remove(downloadKey)
-        downloadProgress.removeValue(forKey: downloadKey)
     }
 
     /// 캐시 파일 경로 생성

--- a/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel+Fetch.swift
+++ b/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel+Fetch.swift
@@ -67,14 +67,10 @@ extension BundleViewModel {
                 BackgroundViewData(background: bg, isOwned: ownedIds.contains(bg.id ?? ""))
             }
 
-            // Lottie 배경 JSON 다운로드 (백그라운드에서 비동기 실행)
+            // Lottie 배경 JSON 다운로드 (뷰 렌더링 전 완료 보장)
             let lottieBackgrounds = items.filter { $0.isLottie }
-            if !lottieBackgrounds.isEmpty {
-                Task {
-                    for bg in lottieBackgrounds {
-                        await LottieItemManager.shared.downloadBackgroundLottie(bg)
-                    }
-                }
+            for bg in lottieBackgrounds {
+                await LottieItemManager.shared.downloadBackgroundLottie(bg)
             }
 
             await MainActor.run {
@@ -98,14 +94,10 @@ extension BundleViewModel {
                 CarabinerViewData(carabiner: cb, isOwned: ownedIds.contains(cb.id ?? ""))
             }
 
-            // Lottie 카라비너 JSON 다운로드 (백그라운드에서 비동기 실행)
+            // Lottie 카라비너 JSON 다운로드 (뷰 렌더링 전 완료 보장)
             let lottieCarabiners = items.filter { $0.isLottie }
-            if !lottieCarabiners.isEmpty {
-                Task {
-                    for cb in lottieCarabiners {
-                        await LottieItemManager.shared.downloadCarabinerLottie(cb)
-                    }
-                }
+            for cb in lottieCarabiners {
+                await LottieItemManager.shared.downloadCarabinerLottie(cb)
             }
 
             await MainActor.run {

--- a/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel.swift
+++ b/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel.swift
@@ -57,18 +57,14 @@ class CollectionViewModel {
         await dataManager.fetchBackgroundsIfNeeded()
         await dataManager.fetchCarabinersIfNeeded()
 
-        // Lottie 아이템 JSON 프리다운로드
+        // Lottie 아이템 JSON 프리다운로드 (뷰 렌더링 전 완료 보장)
         let lottieBackgrounds = dataManager.backgrounds.filter { $0.isLottie }
         let lottieCarabiners = dataManager.carabiners.filter { $0.isLottie }
-        if !lottieBackgrounds.isEmpty || !lottieCarabiners.isEmpty {
-            Task {
-                for bg in lottieBackgrounds {
-                    await LottieItemManager.shared.downloadBackgroundLottie(bg)
-                }
-                for cb in lottieCarabiners {
-                    await LottieItemManager.shared.downloadCarabinerLottie(cb)
-                }
-            }
+        for bg in lottieBackgrounds {
+            await LottieItemManager.shared.downloadBackgroundLottie(bg)
+        }
+        for cb in lottieCarabiners {
+            await LottieItemManager.shared.downloadCarabinerLottie(cb)
         }
     }
 


### PR DESCRIPTION
## 요약
- 오랜만에 앱 접속 시 Lottie 배경이 표시되지 않는 버그가 발생했다.
- 처음에는 로드 실패 시 재시도 로직을 추가하려 했으나,
- 실제 원인은 다운로드 실패가 아니라 **다운로드를 기다리지 않는 코드 구조**였다.
- `Task { }` (fire-and-forget)를 `await`로 변경하여 다운로드 완료 후 화면이 렌더링되도록 수정했다.
- 추가로, 다운로드 실패 시 잘못된 캐시 URL이 저장되던 문제에 방어 로직을 추가했다.

> ❓❓ **모든 유저에게 발생하지 않는 이유** ❓❓
> Lottie JSON은 Caches 디렉토리에 저장되는데, 캐시가 남아있으면 다운로드 자체를 스킵하므로 문제가 없다.
> iOS가 저장공간 부족 등의 이유로 캐시를 자동 정리한 경우에만 재다운로드가 필요하고, 이때 이 버그가 발생한다.
> **그런데, 해결하면서 생각보다 이런 사람이 있긴하겠다 생각이 들었고 적절한 픽스라고 결론.**

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 버그 발생 원인을 배달 비유로 이해하기 (비유형 PR 맛들렸다)

1. 엄마가 저녁 준비를 하는데, 반찬은 직접 만들어서 **다 될 때까지 기다렸지만**,
2. 치킨은 배달 주문만 넣고 **기다리지 않고 바로 상을 차렸습니다.** 
3. 식탁에 앉았더니 치킨 자리가 비어있고, 치킨은 나중에 도착했지만 이미 밥을 다 먹고 치운 뒤였습니다.

> 여기서 **치킨**이 이번 이슈에선 **배경**이었던 것이지
사실 로티 카라비너, 로티 배경이면 뭐든 발생가능한 버그였음.
Lottie가 아닌 아이템들은 별도 경로로 로딩되어 이 버그와 무관함.

### 코드에서의 흐름

`loadBackgroundsAndCarabiners()`에서 Lottie 다운로드를 `Task { }`로 감싸서 실행했습니다.

```swift
// Before: 주문만 넣고 안 기다림
Task {
    for bg in lottieBackgrounds {
        await LottieItemManager.shared.downloadBackgroundLottie(bg)
    }
}
  // ← 함수는 여기서 바로 return
  ```

`Task { }`는 Swift에서 **새로운 비동기 작업을 독립적으로 띄우는 것**이므로,
현재 함수는 다운로드 완료를 기다리지 않고 즉시 다음 단계로 넘어갑니다.

이후 `LottieItemView`가 디스크에서 Lottie JSON을 로드하려 하지만,
파일이 아직 다운로드 중이라 **nil → 빈 배경**이 됩니다!!

### 왜 "가끔, 특정 사람만" 발생했는가? (중요)

Lottie JSON은 **Caches 디렉토리**에 저장되는데,
**iOS는 저장공간이 부족하면 이 디렉토리를 자동으로 정리합니다.**
캐시가 있으면 다운로드 자체를 안 하므로 문제가 없지만,
캐시가 날아간 상태에서만 이 **레이스 컨디션**이 발생합니다.

> 아마.. 이 경우에 
너무 다양한 앱을 사용하는데 잘 정리하지 않거나 (메모리 부족)
진짜 기기 용량이 매우 딸려서 일 확률이 있음.

### 1. fire-and-forget → await 변경 (핵심)

> 어떤 작업(요청)을 실행한 뒤 그 결과가 어떻게 되었는지 
기다리거나 확인하지 않고 바로 다음 단계로 넘어가는 비동기 처리 방식
위에서 얘기한 것 처럼 Swift의 Task임. Await가 없는.

  ```swift
// After: 다운로드 끝날 때까지 기다림
for bg in lottieBackgrounds {
    await LottieItemManager.shared.downloadBackgroundLottie(bg)
}
```

`Task { }` 래핑을 제거하고 직접 `await`하여,
**다운로드 완료 후에 화면이 렌더링되도록 순서를 보장**합니다.

캐시가 있을 때는 즉시 return이므로 **기존과 속도 차이 없음**.

### 2. 다운로드 실패 시 잘못된 캐시 저장 방지

```swift
let success = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
    downloadTask.observe(.success) { _ in
        continuation.resume(returning: true)
    }
    downloadTask.observe(.failure) { snapshot in
        print("[LottieItemManager] 다운로드 실패: \(snapshot.error?.localizedDescription ?? "")")
        continuation.resume(returning: false)
    }
}

```swift
guard success else { return }  // 실패 시 캐시 저장하지 않고 종료
saveCacheURL(...)              // 성공 시에만 저장
```

## Before / After 요약

```
Before: 캐시 없음 → 다운로드 시작만 하고 넘어감 → 빈 배경 → 앱 다시 키고 복귀하면 보임
After:  캐시 없음 → 다운로드 끝날 때까지 기다림 → 정상 표시
```
- `CollectionViewModel.swift` — fire-and-forget 제거
- `BundleViewModel+Fetch.swift` — 동일 패턴 2곳 수정
- `LottieItemManager.swift` — 성공/실패 구분 + 실패 시 캐시 저장 방지

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #113 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
