### PR TITLE
fix: 뭉치 생성/수정 구매 시트 UI 통일 및 애니메이션 문제 개선

### DIFF
--- a/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel+Purchase.swift
+++ b/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel+Purchase.swift
@@ -79,7 +79,7 @@ extension BundleViewModel {
             }
         }
 
-        isPurchasing = false
+        // 성공 시 isPurchasing은 호출자가 refreshData() 완료 후 해제
         return .success
     }
 }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Purchase.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Purchase.swift
@@ -50,7 +50,9 @@ extension BundleCreateView {
             .padding(.horizontal, 20)
             .padding(.bottom, 30)
 
-            // 내 보유 재화와 총 가격
+            Spacer()
+
+            // 내 보유 재화와 총 가격 (하단 고정)
             HStack(spacing: 6) {
                 Text("내 보유 : ")
                     .typography(.suit15M25)
@@ -62,13 +64,10 @@ extension BundleCreateView {
             }
             purchaseButton
                 .padding(.horizontal, 33.2)
-                .padding(.bottom, 40)
                 .adaptiveBottomPadding()
         }
-        .background(
-            UnevenRoundedRectangle(topLeadingRadius: 38, topTrailingRadius: 38)
-                .fill(.white100)
-        )
+        .background(.white100)
+        .presentationDetents([.fraction(0.43)])
     }
 
     // 구매 버튼
@@ -111,6 +110,8 @@ extension BundleCreateView {
             await refreshData()
 
             await MainActor.run {
+                bundleVM.isPurchasing = false
+
                 // ViewModel 상태 동기화
                 if let bg = bundleVM.newSelectedBackground {
                     bundleVM.selectedBackground = bg.background
@@ -120,6 +121,12 @@ extension BundleCreateView {
                 }
 
                 showPurchaseSheet = false
+            }
+
+            // 시트 닫히는 애니메이션 대기
+            try? await Task.sleep(for: .seconds(0.3))
+
+            await MainActor.run {
                 showPurchaseSuccessAlert = true
                 purchasesSuccessScale = 0.3
                 withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
@@ -128,22 +128,6 @@ struct BundleCreateView<Route: BundleRoute>: View {
             alertContent
                 .position(x: screenWidth / 2, y: screenHeight / 2)
 
-            // 구매 시트 오버레이
-            ZStack {
-                Color.black20
-                    .ignoresSafeArea()
-                    .zIndex(10)
-                VStack {
-                    Spacer()
-                    purchaseSheetView
-                }
-                .zIndex(100)
-                .ignoresSafeArea()
-                .transition(.move(edge: .bottom))
-                .animation(.easeInOut(duration: 0.3), value: showPurchaseSheet)
-            }
-            .opacity(showPurchaseSheet ? 1 : 0)
-            .blur(radius: showPurchaseSuccessAlert ? 10 : 0)
         }
         .ignoresSafeArea()
         .navigationBarBackButtonHidden()
@@ -159,6 +143,9 @@ struct BundleCreateView<Route: BundleRoute>: View {
         }
         .onDisappear {
             bundleVM.resetEditState()
+        }
+        .sheet(isPresented: $showPurchaseSheet) {
+            purchaseSheetView
         }
         .sheet(isPresented: $showKeyringSheet) {
             keyringSheetContent

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Purchase.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Purchase.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 extension BundleEditView {
     var purchaseSheetView: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 12) {
             // 상단 섹션 - 닫기 버튼, 타이틀
             HStack {
                 Button {
@@ -26,43 +26,41 @@ extension BundleEditView {
                 Spacer()
             }
             .padding(EdgeInsets(top: 30, leading: 20, bottom: 10, trailing: 20))
-            .padding(.bottom, 12)
-            
+
             // 구매할 아이템 목록
-            ScrollView {
-                VStack(spacing: 20) {
-                    if let bg = bundleVM.newSelectedBackground, !bg.isOwned && bg.background.price > 0 {
-                        BundlePurchaseCartItem(
-                            imageURL: bg.background.backgroundImage,
-                            name: bg.background.backgroundName,
-                            type: "배경",
-                            price: bg.background.price
-                        )
-                    }
-                    if let cb = bundleVM.newSelectedCarabiner, !cb.isOwned && cb.carabiner.price > 0 {
-                        BundlePurchaseCartItem(
-                            imageURL: cb.carabiner.carabinerImage.first ?? "",
-                            name: cb.carabiner.carabinerName,
-                            type: "카라비너",
-                            price: cb.carabiner.price
-                        )
-                    }
+            VStack(spacing: 20) {
+                if let bg = bundleVM.newSelectedBackground, !bg.isOwned && bg.background.price > 0 {
+                    BundlePurchaseCartItem(
+                        imageURL: bg.background.backgroundImage,
+                        name: bg.background.backgroundName,
+                        type: "배경",
+                        price: bg.background.price
+                    )
                 }
-                .padding(.horizontal, 20)
+                if let cb = bundleVM.newSelectedCarabiner, !cb.isOwned && cb.carabiner.price > 0 {
+                    BundlePurchaseCartItem(
+                        imageURL: cb.carabiner.carabinerImage.first ?? "",
+                        name: cb.carabiner.carabinerName,
+                        type: "카라비너",
+                        price: cb.carabiner.price
+                    )
+                }
             }
-            
-            // 내 보유 재화와 총 가격
+            .padding(.horizontal, 20)
+            .padding(.bottom, 30)
+
+            Spacer()
+
+            // 내 보유 재화와 총 가격 (하단 고정)
             HStack(spacing: 6) {
                 Text("내 보유 : ")
                     .typography(.suit15M25)
                     .foregroundStyle(.black100)
+                    .padding(.vertical, 4.5)
                 Text("\(UserManager.shared.currentUser?.coin ?? 0)")
                     .typography(.nanum16EB)
                     .foregroundStyle(.main500)
-                    .padding(.top, 2)
             }
-            .padding(.top, 20)
-            
             purchaseButton
                 .padding(.horizontal, 33.2)
                 .adaptiveBottomPadding()
@@ -109,7 +107,14 @@ extension BundleEditView {
         case .success:
             // 모든 구매 성공
             await MainActor.run {
+                bundleVM.isPurchasing = false
                 showPurchaseSheet = false
+            }
+
+            // 시트 닫히는 애니메이션 대기
+            try? await Task.sleep(for: .seconds(0.3))
+
+            await MainActor.run {
                 showPurchaseSuccessAlert = true
                 purchasesSuccessScale = 0.3
                 withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {


### PR DESCRIPTION
## 요약

https://github.com/user-attachments/assets/e587ba35-5d88-45c2-ac5e-cbdad6551b76

> 뭉생, 뭉수에서 아이템 구매하면 위 영상처럼 파박하면서 시트가 사라졌다.

- **뭉치 생성/수정 화면의 구매 시트가 닫힐 때 애니메이션 없이 "파박" 사라지던 문제 수정**
- 생성/수정 화면 구매 시트를 `.sheet()`으로 통일하고, UI spacing도 일관되게 맞춤
	- 생성은 커스텀, 수정은 .sheet 였다. 왜 이제 발견했지?

- 구매 완료 후 데이터 갱신 중 로딩 상태가 풀려서 멈춰 보이던 문제 개선
  
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 1. 구매 시트 `.sheet()`으로 통일

```swift
// Before: 커스텀 ZStack 오버레이 (transition 미동작)
ZStack { ... }
.opacity(showPurchaseSheet ? 1 : 0)

// After: 시스템 .sheet() (dismiss 애니메이션 자동 적용)
.sheet(isPresented: $showPurchaseSheet) {
    purchaseSheetView
  }
```

### 2. 시트 닫힘 → Alert 표시 사이 0.3초 대기 추가 (성공 시)

```swift
showPurchaseSheet = false

try? await Task.sleep(for: .seconds(0.3))   // 시트 dismiss 애니메이션 대기

showPurchaseSuccessAlert = true
```

> 구매 실패 시와 동일한 패턴으로 통일.

### 3. 로딩 상태를 refreshData() 완료까지 유지

```swift
// Before: purchaseSelectedItems() 내부에서 즉시 해제
isPurchasing = false
return .success

// After: 호출자에서 refreshData() 완료 후 해제
await refreshData()
bundleVM.isPurchasing = false
showPurchaseSheet = false
```

> 이건, 실제로 우리가 아이템 구매 로직 실행하면 
파이어스토어 관련 로직이 4개가 돌아가는데 
해당 로직이 느리진 않지만, 환경에 따라 속도 차이가 있어보여서 
실제 모두 완료 콜백을 해야, 성공 Alert가 등장하도록 함.

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
<img width="300" alt="수정 시트" src="https://github.com/user-attachments/assets/deb1c41b-aa59-4328-be7f-e8790a349b4f" />
<img width="300" alt="만들기 시트" src="https://github.com/user-attachments/assets/2f130197-77ca-4991-846a-f50cdee3cbd3" />

> 수정/만들기 시트가 시트 구현 방식이 달랐던 모습.
현재는 둘 다 .sheet 모디파이어 사용으로 수정 완료


https://github.com/user-attachments/assets/72e2ed89-6e1b-49a0-8e37-302de0515821

> 파바박 시트 내려가는거 해결한 영상




## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #115 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
