### PR TITLE
style: 슬라이더 굵기 조절 버튼 터치 영역 확장

### DIFF
--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/ClearSketch/Views/ClearSketchDrawingView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/ClearSketch/Views/ClearSketchDrawingView.swift
@@ -176,7 +176,7 @@ extension ClearSketchDrawingView {
             HStack {
                 // 커스텀 슬라이더
                 customSlider
-                    .padding(.leading, 10)
+                    .padding(.leading, 4)
                 
                 Spacer()
 
@@ -244,6 +244,8 @@ extension ClearSketchDrawingView {
                         .fill(.white)
                         .frame(width: controlSize, height: controlSize)
                         .glassEffect(.regular)
+                        .padding(12)  // 터치 영역 추가
+                        .contentShape(Rectangle())  // 패딩 영역도 터치 가능하게
                         .offset(y: -thumbPosition)
                         .scaleEffect(isDragging ? 1.1 : 1.0)
                         .animation(.easeInOut(duration: 0.2), value: isDragging)


### PR DESCRIPTION
## 🎯 PR 내용
### 슬라이더 굵기 조절 버튼 터치 영역 확장
클리어 스케치 템플릿에서 드로잉을 위한 선 굵기 조절 버튼을 눌렀을 때,
터치 영역의 범위가 좁다는 피드백을 반영하여 터치 영역을 확장함.

```swift
                    Circle()
                        .fill(.white)
                        .frame(width: controlSize, height: controlSize)
                        .glassEffect(.regular)
                        .padding(12)  // 터치 영역 추가
                        .contentShape(Rectangle())  // 패딩 영역도 터치 가능하게
```


## 📱 스크린샷 (UI 변경 시)

> 여러번 시도해봤을 때, 옆으로 몇번 그어진 선 안쪽으로는 모두 버튼이 제대로 눌렸음 
> 이전보다 굵기 조절이 확실히 편해짐!

https://github.com/user-attachments/assets/9fa3de10-3acf-4def-9a52-0756df896714



## 🔗 관련 이슈
#117 

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
