### PR TITLE
fix: [앱 업데이트] - 업데이트 Alert 링크 앱스토어 연결 실패 해결 

### DIFF
--- a/Keychy/Keychy/Core/Update/AppUpdateManager.swift
+++ b/Keychy/Keychy/Core/Update/AppUpdateManager.swift
@@ -16,7 +16,7 @@ class AppUpdateManager {
     var showUpdateAlert = false
     var appStoreURL = ""
 
-    private let appStoreID = "6738383686"
+    private let appStoreID = "6754951347"
 
     /// 앱 업데이트 체크
     func checkForUpdate() async {


### PR DESCRIPTION

<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

**앱스토어 업데이트 알림 링크가 유효하지 않았던 문제가 있었습니다.**

**실제 로직이** 

```swift
private let appStoreID = "6754951347"
```

**이렇게 불변하는 appStoreID를 상수로 두고** 

```swift
appStoreURL = "https://apps.apple.com/app/id\(appStoreID)"
```
**업데이트가 필요한 경우 해당 주소값으로 리다이렉션 시킵니다.** 

### **그런데, 이 appID가 다른 값이 들어가있더라고요.**

찾아보면.. 이 값은 절대 변하지 않는 주민등록번호같은거라는데
흠.. 뭔가 배포전에 구현했던거도 아닌거같은데?   

아무튼 교체했고, 다음 업데이트때 체크가 필요해보이고,
그리고 다음 버전 배포 후에, 이 값이 변하는지 체크해보겠습니다.

> 이 값은, 앱스토어커넥트에서 확인이 가능함.

### before: 6738383686
### after: 6754951347


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
<img width="400" alt="스크린샷 2026-03-01 16 39 39" src="https://github.com/user-attachments/assets/880863fe-7554-4d0f-a33f-6aa6e0af4f2e" />
> 바뀐 ID의 링크 테스트는 성공



## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #122 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
