### PR TITLE
fix: 탭바 스크롤 축소 동작 제거

### DIFF
--- a/Keychy/Keychy/Presentation/Tab/Views/MainTabView.swift
+++ b/Keychy/Keychy/Presentation/Tab/Views/MainTabView.swift
@@ -52,7 +52,6 @@ extension MainTabView {
             collectionTab
         }
         .tint(.main500)
-        .tabBarMinimizeBehavior(.onScrollDown)
         .onAppear(perform: viewModel.handleAppear)
         .onChange(of: viewModel.deepLinkManager.pendingPostOfficeId, viewModel.handleDeepLinkChange)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### `MainTabView`의 `.tabBarMinimizeBehavior(.onScrollDown)` 제거

스크롤 시 탭바가 자동 축소되는 기능이 **탭마다 다르게 동작**하는 문제가 있었습니다.

예를 들어 공방 뭉치탭에서는 축소가 정상 동작하지만, 공방 키링탭에서는 동작하지 않았습니다.

### 원인
키링탭에만 존재하는 **수평 ScrollView**(최근 사용 템플릿)가 
메인 수직 ScrollView와 중첩되면서, 시스템이 수직 스크롤 이벤트를 제대로 감지하지 못했기 때문입니다.

  탭별 동작 불일치로 UX가 일관되지 않아 축소 기능 자체를 제거했습니다.

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #133 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
