### PR TITLE
fix: 템플릿 프리뷰 로딩 UI 개선

### DIFF
--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
@@ -39,29 +39,35 @@ struct TemplatePreviewBody: View {
 
     var body: some View {
         ZStack {
-            VStack(alignment: .leading, spacing: 0) {
-                Spacer()
-                
-                // 프리뷰 이미지
-                templatePreview
-                
-                Spacer()
-                
+            if template == nil {
+                // fetch 중 — 로딩 인디케이터만 표시
+                LoadingAlert(type: .short40, message: nil)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
                 VStack(alignment: .leading, spacing: 0) {
-                    // 템플릿 정보
-                    infoSection
-                        .padding(.bottom, 40)
-                        .frame(minHeight: 120, alignment: .top)
-                    
-                    // 액션 버튼
-                    actionButton
-                        .adaptiveBottomPadding()
-                        .padding(.bottom, getBottomPadding(40) == 0 ? 40 : 0)
+                    Spacer()
+
+                    // 프리뷰 이미지
+                    templatePreview
+
+                    Spacer()
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        // 템플릿 정보
+                        infoSection
+                            .padding(.bottom, 40)
+                            .frame(minHeight: 120, alignment: .top)
+
+                        // 액션 버튼
+                        actionButton
+                            .adaptiveBottomPadding()
+                            .padding(.bottom, getBottomPadding(40) == 0 ? 40 : 0)
+                    }
+                    .padding(.horizontal, 34)
+
                 }
-                .padding(.horizontal, 34)
-                
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
             
             CustomNavigationBar {
                 BackToolbarButton {
@@ -184,7 +190,6 @@ extension TemplatePreviewBody {
 
             if let template {
                 if template.previewImages.count > 1 {
-                    // 슬라이드 이미지
                     TemplateImageSlideshow(
                         imageURLs: template.previewImages,
                         localFirstImageName: "preview_\(template.id ?? "")"
@@ -192,13 +197,10 @@ extension TemplatePreviewBody {
                         .scaledToFit()
                         .frame(width: 386, height: 386)
                 } else {
-                    // fallback: 기존 단일 프리뷰 이미지
                     ItemDetailImage(itemURL: template.previewURL)
                         .scaledToFit()
                         .frame(width: 386, height: 386)
                 }
-            } else {
-                LoadingAlert(type: .short40, message: nil)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: 500)
@@ -209,8 +211,6 @@ extension TemplatePreviewBody {
         Group {
             if let template {
                 ItemDetailInfoSection(item: template)
-            } else {
-                Text("템플릿 정보 없음")
             }
         }
     }
@@ -236,8 +236,6 @@ extension TemplatePreviewBody {
                         }
                     }
                 )
-            } else {
-                LoadingAlert(type: .short40, message: nil)
             }
         }
     }


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->


 ## Summary
### 템플릿 프리뷰 화면 fetch 중 로딩 상태를 `LoadingAlert(.short40)` 하나로 통일

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

  ### 템플릿 프리뷰 로딩
  네트워크가 느린 환경에서 템플릿 프리뷰 진입 시 Firebase fetch가 완료되기 전까지 로딩 스피너 2개 + "템플릿 정보 없음" 텍스트가 동시에 표시되는 문제가 있었습니다.

  `template`이 nil(fetch 중)일 때 하위 컴포넌트 3곳에서 각각 nil 분기를 처리하고 있었기 때문입니다. 
`body`에서 nil 여부를 먼저 분기하여 **로딩 화면 하나만 표시하도록 수정했습니다.**

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

> 실제 네트워크를 느리게 하기 어려워서 후에 싱싱 직접 테스트 해보세요.

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #134 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
