### PR TITLE
fix: [위젯] - 말 템플릿 오프셋 버그 및 이미지 잘림 오류 해결

### DIFF
--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
@@ -29,7 +29,7 @@ enum KeyringScale {
         "ClearSketch": CGSize(width: 210, height: 210),
         "PixelKeyring": CGSize(width: 277, height: 257),
         "SpeechBubble": CGSize(width: 360, height: 249),
-        "WishHorse26": CGSize(width: 269, height: 310),
+        "WishHorse26": CGSize(width: 280, height: 310),
         "DuZzonKu": CGSize(width: 376, height: 376)
     ]
 

--- a/Keychy/Keychy/Core/Widget/KeyringFrameCompositor.swift
+++ b/Keychy/Keychy/Core/Widget/KeyringFrameCompositor.swift
@@ -124,7 +124,7 @@ nonisolated enum KeyringFrameCompositor {
         let bodyOffsetY = KeyringScale.widgetBodyOffsetY(for: template)
 
         // 오버플로 방지: 바디가 피벗 아래로 매달리므로 캔버스 절반 기준으로 제한
-        let maxAllowed = CGFloat(frameSize) * 0.65
+        let maxAllowed = CGFloat(frameSize) * 0.68
         let bodyMaxDim = max(CGFloat(bodyWidth), CGFloat(bodyHeight))
         let bodyClampScale = min(maxAllowed / bodyMaxDim, 1.0)
 


### PR DESCRIPTION
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

<img width="326" height="336" alt="image" src="https://github.com/user-attachments/assets/988ff9b1-9433-4878-ae3e-3fd86c6f8bda" />

### 리엘의 제보로 말키링의 오프셋이 이상한 오류가 있었습니다. 
분석해보니, 리엘이 과거 개발과정에서 만든 **샘플 키링**이라 생긴 버그였습니다. 
> 템플릿마다 고유 y offset이 있습니다. 
해당 오프셋이 적용되지않은 키링 데이터였기에 발생했던 오류. 
~~다행이다~~

<img width="275" height="312" alt="image" src="https://github.com/user-attachments/assets/24cd4f39-87b0-44f6-a37f-ab0d5d65f0bc" />

### 기울여지지않은 말키링의 경우 앞코 부분이 잘리는 오류가 있었습니다. 
원인은, 위젯 합성 시 바디 이미지를 `centerCropAndResize`로 `KeyringScale.maxSize` 비율에 맞춰 중앙 크롭하는데, 
**WishHorse26의 maxSize 가로(269)가 실제 말 바디 이미지 비율보다 좁아서** 좌우가 균등하게 잘렸습니다. 

**WishHorse26 maxSize width를 269 → 280으로 확대하여 실제 바디 비율에 맞춤.**


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

<img width="300"  alt="앞코 짤리는거 해결" src="https://github.com/user-attachments/assets/cfa6575b-9a4c-4bcc-bba4-a3a9e2c533d2" />

> 해결

**++ 위젯에 보이는 바디 이미지 조금 키움.**

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #141 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
