### PR TITLE
refactor: 뭉치 생성/수정 - 정적 배경·카라비너 재로딩 버그 수정 및 로딩 성능 개선

### DIFF
--- a/Keychy/Keychy/Core/Firebase/StorageManager.swift
+++ b/Keychy/Keychy/Core/Firebase/StorageManager.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import FirebaseStorage
+import CryptoKit
 
 @Observable
 class StorageManager {
@@ -15,7 +16,13 @@ class StorageManager {
     
     private var imageCache: [String: UIImage] = [:]
     private let cacheQueue = DispatchQueue(label: "com.keychy.storageCache", attributes: .concurrent)
-    
+
+    // iOS가 저장공간 부족 시 자동 정리해주는 cachesDirectory 사용
+    private var diskCacheDirectory: URL {
+        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        return cacheDir.appendingPathComponent("StorageImageCache")
+    }
+
     private init() {}
     
     func getData(path: String) async throws -> Data {
@@ -30,22 +37,30 @@ class StorageManager {
     }
     
     // MARK: - URL에서 이미지 가져오기
+    // 로드 순서: 메모리 캐시 → 디스크 캐시 → 네트워크
     func getImage(path: String) async throws -> UIImage {
-        // 캐시 확인
+        // 1) 메모리 캐시 확인 (즉시)
         if let cachedImage = getCachedImage(for: path) {
             return cachedImage
         }
-        
+
+        // 2) 디스크 캐시 확인 (~5ms)
+        if let diskImage = getDiskCachedImage(for: path) {
+            setCachedImage(diskImage, for: path)
+            return diskImage
+        }
+
+        // 3) 네트워크 다운로드 → 메모리 + 디스크 캐시 저장
         let data = try await getData(path: path)
-        
+
         guard let image = UIImage(data: data) else {
             print("이미지 변환 실패: \(path)")
             throw URLError(.badServerResponse)
         }
-        
-        // 캐시에 저장
+
         setCachedImage(image, for: path)
-        
+        saveToDiskCache(data, for: path)
+
         return image
     }
     
@@ -82,20 +97,66 @@ class StorageManager {
         }
     }
     
-    // 특정 이미지 캐시 삭제
+    // 특정 이미지 캐시 삭제 (메모리 + 디스크)
     func removeCachedImage(for path: String) {
         cacheQueue.async(flags: .barrier) {
             self.imageCache.removeValue(forKey: path)
-            print("캐시 삭제: \(path)")
         }
+        removeDiskCachedImage(for: path)
     }
-    
-    // 전체 캐시 삭제
+
+    // 전체 캐시 삭제 (메모리 + 디스크)
     func clearCache() {
         cacheQueue.async(flags: .barrier) {
             self.imageCache.removeAll()
-            print("이미지 캐시 전체 삭제")
         }
+        clearDiskCache()
+    }
+
+    /// 메모리 캐시 또는 디스크 캐시에 해당 path의 이미지가 존재하는지 동기적으로 확인
+    func isCached(path: String) -> Bool {
+        if getCachedImage(for: path) != nil { return true }
+        let fileURL = diskCacheDirectory.appendingPathComponent(diskCacheKey(for: path))
+        return FileManager.default.fileExists(atPath: fileURL.path)
+    }
+
+    // MARK: - 디스크 캐시
+
+    /// URL → SHA256 해시 문자열 (파일명으로 안전하게 사용 가능)
+    private func diskCacheKey(for path: String) -> String {
+        let digest = SHA256.hash(data: Data(path.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// 디스크에서 이미지 읽기
+    private func getDiskCachedImage(for path: String) -> UIImage? {
+        let fileURL = diskCacheDirectory.appendingPathComponent(diskCacheKey(for: path))
+        guard let data = try? Data(contentsOf: fileURL),
+              let image = UIImage(data: data) else {
+            return nil
+        }
+        return image
+    }
+
+    /// 원본 Data를 디스크에 저장 (백그라운드에서 실행)
+    private func saveToDiskCache(_ data: Data, for path: String) {
+        let dir = diskCacheDirectory
+        let fileURL = dir.appendingPathComponent(diskCacheKey(for: path))
+        DispatchQueue.global(qos: .utility).async {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try? data.write(to: fileURL, options: .atomic)
+        }
+    }
+
+    /// 개별 디스크 캐시 삭제
+    private func removeDiskCachedImage(for path: String) {
+        let fileURL = diskCacheDirectory.appendingPathComponent(diskCacheKey(for: path))
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    /// 전체 디스크 캐시 삭제
+    private func clearDiskCache() {
+        try? FileManager.default.removeItem(at: diskCacheDirectory)
     }
 
     // MARK: - 업로드

--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
@@ -27,7 +27,7 @@ enum KeyringScale {
         "Polaroid": CGSize(width: 265, height: 324),
         "AcrylicPhoto": CGSize(width: 360, height: 360),
         "ClearSketch": CGSize(width: 210, height: 210),
-        "PixelKeyring": CGSize(width: 277, height: 257),
+        "PixelKeyring": CGSize(width: 277, height: 277),
         "SpeechBubble": CGSize(width: 360, height: 249),
         "WishHorse26": CGSize(width: 280, height: 310),
         "DuZzonKu": CGSize(width: 376, height: 376)

--- a/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel+Fetch.swift
+++ b/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel+Fetch.swift
@@ -67,10 +67,14 @@ extension BundleViewModel {
                 BackgroundViewData(background: bg, isOwned: ownedIds.contains(bg.id ?? ""))
             }
 
-            // Lottie 배경 JSON 다운로드 (뷰 렌더링 전 완료 보장)
+            // Lottie 배경 JSON 병렬 다운로드 (뷰 렌더링 전 완료 보장)
             let lottieBackgrounds = items.filter { $0.isLottie }
-            for bg in lottieBackgrounds {
-                await LottieItemManager.shared.downloadBackgroundLottie(bg)
+            await withTaskGroup(of: Void.self) { group in
+                for bg in lottieBackgrounds {
+                    group.addTask {
+                        await LottieItemManager.shared.downloadBackgroundLottie(bg)
+                    }
+                }
             }
 
             await MainActor.run {
@@ -94,10 +98,14 @@ extension BundleViewModel {
                 CarabinerViewData(carabiner: cb, isOwned: ownedIds.contains(cb.id ?? ""))
             }
 
-            // Lottie 카라비너 JSON 다운로드 (뷰 렌더링 전 완료 보장)
+            // Lottie 카라비너 JSON 병렬 다운로드 (뷰 렌더링 전 완료 보장)
             let lottieCarabiners = items.filter { $0.isLottie }
-            for cb in lottieCarabiners {
-                await LottieItemManager.shared.downloadCarabinerLottie(cb)
+            await withTaskGroup(of: Void.self) { group in
+                for cb in lottieCarabiners {
+                    group.addTask {
+                        await LottieItemManager.shared.downloadCarabinerLottie(cb)
+                    }
+                }
             }
 
             await MainActor.run {

--- a/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel.swift
+++ b/Keychy/Keychy/Presentation/Bundle/ViewModels/BundleViewModel.swift
@@ -20,6 +20,7 @@
 //   +Views     - UI 컴포넌트
 
 import SwiftUI
+import Nuke
 import FirebaseFirestore
 import FirebaseStorage
 
@@ -84,6 +85,10 @@ class BundleViewModel {
 
     var isLoading = false
     var isPurchasing = false
+
+    // MARK: - 이미지 프리페처 (ARC 해제 방지용)
+    /// 로컬 변수로 생성하면 함수 종료 시 해제되어 프리페치 취소됨
+    @ObservationIgnored var imagePrefetcher: ImagePrefetcher?
 
     // MARK: - 정렬 상태
     

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Initialization.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Initialization.swift
@@ -36,27 +36,25 @@ extension BundleCreateView {
         let currentBackgroundId = bundleVM.newSelectedBackground?.background.id
         let currentCarabinerId = bundleVM.newSelectedCarabiner?.carabiner.id
 
-        // 배경 데이터 새로고침
-        await withCheckedContinuation { continuation in
+        // 배경 + 카라비너 병렬 새로고침
+        async let bgRefresh: Void = withCheckedContinuation { continuation in
             bundleVM.fetchAllBackgrounds { _ in
-                // 이전에 선택했던 배경을 다시 찾아서 선택 (구매 상태가 업데이트됨)
                 if let bgId = currentBackgroundId {
                     self.bundleVM.newSelectedBackground = bundleVM.backgroundViewData.first { $0.background.id == bgId }
                 }
                 continuation.resume()
             }
         }
-
-        // 카라비너 데이터 새로고침
-        await withCheckedContinuation { continuation in
+        async let cbRefresh: Void = withCheckedContinuation { continuation in
             bundleVM.fetchAllCarabiners { _ in
-                // 이전에 선택했던 카라비너를 다시 찾아서 선택 (구매 상태가 업데이트됨)
                 if let cbId = currentCarabinerId {
                     self.bundleVM.newSelectedCarabiner = bundleVM.carabinerViewData.first { $0.carabiner.id == cbId }
                 }
                 continuation.resume()
             }
         }
+        await bgRefresh
+        await cbRefresh
     }
 
     /// 사용자가 소유한 배경과 카라비너 아이템들을 로드
@@ -67,19 +65,15 @@ extension BundleCreateView {
 
         let uid = UserManager.shared.userUID
 
-        // 배경 데이터 로드
-        await withCheckedContinuation { continuation in
-            bundleVM.fetchAllBackgrounds { _ in
-                continuation.resume()
-            }
+        // 배경 + 카라비너 병렬 로드
+        async let bgTask: Void = withCheckedContinuation { continuation in
+            bundleVM.fetchAllBackgrounds { _ in continuation.resume() }
         }
-
-        // 카라비너 데이터 로드
-        await withCheckedContinuation { continuation in
-            bundleVM.fetchAllCarabiners { _ in
-                continuation.resume()
-            }
+        async let cbTask: Void = withCheckedContinuation { continuation in
+            bundleVM.fetchAllCarabiners { _ in continuation.resume() }
         }
+        await bgTask
+        await cbTask
 
         // 코인 충전 후 복귀 시 저장된 선택 복원
         bundleVM.restoreSelectionIfNeeded()

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Initialization.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Initialization.swift
@@ -24,6 +24,7 @@ extension BundleCreateView {
         let cbURLs = bundleVM.carabinerViewData.compactMap { URL(string: $0.carabiner.carabinerImage[0]) }
         let prefetcher = ImagePrefetcher()
         prefetcher.startPrefetching(with: bgURLs + cbURLs)
+        bundleVM.imagePrefetcher = prefetcher
     }
 
     /// 화면이 다시 나타날 때 데이터 새로고침

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
@@ -98,6 +98,11 @@ extension BundleCreateView {
                     viewModel: bundleVM,
                     selectedBG: bundleVM.newSelectedBackground,
                     onBackgroundTap: { bg in
+                        // 정적 배경 + 캐시 미스일 때만 로딩 표시
+                        if !bg.background.isLottie
+                            && !StorageManager.shared.isCached(path: bg.background.backgroundImage) {
+                            isBackgroundLoading = true
+                        }
                         bundleVM.newSelectedBackground = bg
                     }
                 )
@@ -106,7 +111,10 @@ extension BundleCreateView {
                     viewModel: bundleVM,
                     selectedCarabiner: bundleVM.newSelectedCarabiner,
                     onCarabinerTap: { carabiner in
-                        if carabiner.carabiner.isLottie { isSceneReady = false }
+                        // 정적 카라비너 + 캐시 미스일 때만 로딩 표시
+                        if !carabiner.carabiner.isLottie && !isCarabinerCached(carabiner) {
+                            isSceneReady = false
+                        }
                         bundleVM.newSelectedCarabiner = carabiner
                     }
                 )
@@ -144,6 +152,10 @@ extension BundleCreateView {
                     }
                     selectedKeyrings[selectedPosition] = keyring
                     keyringOrder.append(selectedPosition)
+                    // 키링 바디 이미지 캐시 미스 시 로딩 표시
+                    if !StorageManager.shared.isCached(path: keyring.bodyImage) {
+                        isSceneReady = false
+                    }
                     showKeyringSheet = false
                 }
                 sceneRefreshId = UUID()
@@ -158,6 +170,14 @@ extension BundleCreateView {
         .padding(.horizontal, 20)
         .presentationDetents([.fraction(0.45), .fraction(0.95)])
         .presentationDragIndicator(.visible)
+    }
+
+    // MARK: - 카라비너 캐시 확인
+    /// 카라비너의 front/back 이미지가 모두 캐시되어 있는지 확인
+    private func isCarabinerCached(_ cb: CarabinerViewData) -> Bool {
+        [cb.carabiner.backImageURL, cb.carabiner.frontImageURL]
+            .compactMap { $0 }
+            .allSatisfy { StorageManager.shared.isCached(path: $0) }
     }
 
     // MARK: - 정렬된 키링 목록 (필터링은 KeyringSelectionContent에서 처리)

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
@@ -92,27 +92,25 @@ extension BundleCreateView {
     }
     
     var itemSheetContent: some View {
-        ZStack(alignment: .top) {
-            SelectBackgroundSheet(
-                viewModel: bundleVM,
-                selectedBG: bundleVM.newSelectedBackground,
-                onBackgroundTap: { bg in
-                    bundleVM.newSelectedBackground = bg
-                }
-            )
-            .opacity(isBackgroundMode ? 1 : 0)
-            .allowsHitTesting(isBackgroundMode)
-
-            SelectCarabinerSheet(
-                viewModel: bundleVM,
-                selectedCarabiner: bundleVM.newSelectedCarabiner,
-                onCarabinerTap: { carabiner in
-                    if carabiner.carabiner.isLottie { isSceneReady = false }
-                    bundleVM.newSelectedCarabiner = carabiner
-                }
-            )
-            .opacity(isBackgroundMode ? 0 : 1)
-            .allowsHitTesting(!isBackgroundMode)
+        Group {
+            if isBackgroundMode {
+                SelectBackgroundSheet(
+                    viewModel: bundleVM,
+                    selectedBG: bundleVM.newSelectedBackground,
+                    onBackgroundTap: { bg in
+                        bundleVM.newSelectedBackground = bg
+                    }
+                )
+            } else {
+                SelectCarabinerSheet(
+                    viewModel: bundleVM,
+                    selectedCarabiner: bundleVM.newSelectedCarabiner,
+                    onCarabinerTap: { carabiner in
+                        if carabiner.carabiner.isLottie { isSceneReady = false }
+                        bundleVM.newSelectedCarabiner = carabiner
+                    }
+                )
+            }
         }
     }
     

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
@@ -48,6 +48,8 @@ struct BundleCreateView<Route: BundleRoute>: View {
 
     // 배경 로딩 상태 (정적 배경 캐시 미스 시)
     @State var isBackgroundLoading = false
+    // 최초 씬 로딩 완료 여부 (아이템 변경 로딩과 분리)
+    @State var hasInitiallyLoaded = false
 
     // 구매 Alert 애니메이션
     @State var showPurchaseSuccessAlert = false
@@ -95,6 +97,7 @@ struct BundleCreateView<Route: BundleRoute>: View {
                             // (카라비너 Lottie 프리렌더링 + 키링 로드 + 물리 활성화 후)
                             withAnimation(.easeOut(duration: 0.3)) {
                                 isSceneReady = true
+                                hasInitiallyLoaded = true
                             }
                         }
                     )
@@ -116,11 +119,18 @@ struct BundleCreateView<Route: BundleRoute>: View {
                     .blur(radius: showPurchaseSuccessAlert || isCapturing ? 10 : 0)
             }
 
-            // 씬 로딩 중 또는 정적 배경 다운로드 중 (시트 포함 전체 차단)
-            if !isSceneReady || isBackgroundLoading {
+            // 최초 진입 로딩
+            if !hasInitiallyLoaded {
                 Color.black20
                     .ignoresSafeArea()
                 LoadingAlert(type: .longWithKeychy, message: "아이템을 불러오고 있어요")
+            }
+
+            // 아이템 변경 시 캐시 미스 로딩 (최초 로딩 이후에만)
+            if hasInitiallyLoaded && (!isSceneReady || isBackgroundLoading) {
+                Color.black20
+                    .ignoresSafeArea()
+                LoadingAlert(type: .short40, message: nil)
             }
 
             // 캡처 중 로딩

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
@@ -46,6 +46,9 @@ struct BundleCreateView<Route: BundleRoute>: View {
     // 구매 시트
     @State var showPurchaseSheet = false
 
+    // 배경 로딩 상태 (정적 배경 캐시 미스 시)
+    @State var isBackgroundLoading = false
+
     // 구매 Alert 애니메이션
     @State var showPurchaseSuccessAlert = false
     @State var purchasesSuccessScale: CGFloat = 0.3
@@ -84,6 +87,9 @@ struct BundleCreateView<Route: BundleRoute>: View {
                         carabinerWidth: cb.carabiner.carabinerWidth,
                         currentCarabinerType: cb.carabiner.type,
                         cleanupOnDisappear: true,
+                        onBackgroundLoaded: {
+                            isBackgroundLoading = false
+                        },
                         onAllKeyringsReady: {
                             // onSetupComplete에서 호출됨
                             // (카라비너 Lottie 프리렌더링 + 키링 로드 + 물리 활성화 후)
@@ -110,8 +116,8 @@ struct BundleCreateView<Route: BundleRoute>: View {
                     .blur(radius: showPurchaseSuccessAlert || isCapturing ? 10 : 0)
             }
 
-            // Lottie 씬 로딩 중 (시트 포함 전체 차단)
-            if !isSceneReady {
+            // 씬 로딩 중 또는 정적 배경 다운로드 중 (시트 포함 전체 차단)
+            if !isSceneReady || isBackgroundLoading {
                 Color.black20
                     .ignoresSafeArea()
                 LoadingAlert(type: .longWithKeychy, message: "아이템을 불러오고 있어요")

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Alert.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Alert.swift
@@ -41,8 +41,8 @@ extension BundleEditView {
                                 bundleVM.selectedKeyrings.removeAll()
                                 bundleVM.keyringOrder.removeAll()
                                 
-                                // 3) 새 카라비너 적용 (Lottie면 로딩 표시)
-                                if selectCarabiner?.carabiner.isLottie == true {
+                                // 3) 새 카라비너 적용 (정적 + 캐시 미스일 때만 로딩 표시)
+                                if let cb = selectCarabiner, !cb.carabiner.isLottie, !isCarabinerCached(cb) {
                                     isSceneReady = false
                                 }
                                 bundleVM.newSelectedCarabiner = selectCarabiner
@@ -108,11 +108,19 @@ extension BundleEditView {
         }
     }
     
+    // MARK: - 카라비너 캐시 확인
+    /// 카라비너의 front/back 이미지가 모두 캐시되어 있는지 확인
+    private func isCarabinerCached(_ cb: CarabinerViewData) -> Bool {
+        [cb.carabiner.backImageURL, cb.carabiner.frontImageURL]
+            .compactMap { $0 }
+            .allSatisfy { StorageManager.shared.isCached(path: $0) }
+    }
+
     // MARK: - 로딩 오버레이
     var loadingOverlay: some View {
         Group {
-            // 첫 진입 : 씬 준비 + 사용자 보유 키링 로딩이 모두 끝나야 사라짐
-            if (!isSceneReady || isKeyringSheetLoading) && !isNavigatingAway {
+            // 첫 진입 : 씬 준비 + 사용자 보유 키링 로딩 + 배경 다운로드가 모두 끝나야 사라짐
+            if (!isSceneReady || isKeyringSheetLoading || isBackgroundLoading) && !isNavigatingAway {
                 Color.black20
                     .ignoresSafeArea()
                     .zIndex(100)

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Alert.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Alert.swift
@@ -119,12 +119,20 @@ extension BundleEditView {
     // MARK: - 로딩 오버레이
     var loadingOverlay: some View {
         Group {
-            // 첫 진입 : 씬 준비 + 사용자 보유 키링 로딩 + 배경 다운로드가 모두 끝나야 사라짐
-            if (!isSceneReady || isKeyringSheetLoading || isBackgroundLoading) && !isNavigatingAway {
+            // 최초 진입 로딩
+            if !hasInitiallyLoaded && !isNavigatingAway {
                 Color.black20
                     .ignoresSafeArea()
                     .zIndex(100)
                 LoadingAlert(type: .longWithKeychy, message: "키링 뭉치를 불러오고 있어요")
+                    .zIndex(101)
+            }
+            // 아이템 변경 시 캐시 미스 로딩 (최초 로딩 이후에만)
+            if hasInitiallyLoaded && (!isSceneReady || isBackgroundLoading) && !isNavigatingAway {
+                Color.black20
+                    .ignoresSafeArea()
+                    .zIndex(100)
+                LoadingAlert(type: .short40, message: nil)
                     .zIndex(101)
             }
             if isCapturing {

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Initialization.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Initialization.swift
@@ -27,6 +27,7 @@ extension BundleEditView {
         let cbURLs = bundleVM.carabinerViewData.compactMap { URL(string: $0.carabiner.carabinerImage[0]) }
         let prefetcher = ImagePrefetcher()
         prefetcher.startPrefetching(with: bgURLs + cbURLs)
+        bundleVM.imagePrefetcher = prefetcher
     }
     
     func resetSceneState() {

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Initialization.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+Initialization.swift
@@ -46,47 +46,41 @@ extension BundleEditView {
     }
     
     func loadBackgroundAndCarabiner() async {
-        await withCheckedContinuation { continuation in
-            bundleVM.fetchAllBackgrounds { _ in
-                // 현재 뭉치의 배경으로 항상 초기화
-                if let selectedBundle = bundleVM.selectedBundle {
-                    bundleVM.newSelectedBackground = bundleVM.backgroundViewData.first { bgData in
-                        bgData.background.id == selectedBundle.selectedBackground
-                    }
-                }
+        // 배경 + 카라비너 병렬 로드
+        async let bgTask: Void = withCheckedContinuation { continuation in
+            bundleVM.fetchAllBackgrounds { _ in continuation.resume() }
+        }
+        async let cbTask: Void = withCheckedContinuation { continuation in
+            bundleVM.fetchAllCarabiners { _ in continuation.resume() }
+        }
+        await bgTask
+        await cbTask
 
-                bundleVM.fetchAllCarabiners { _ in
-                    // 현재 뭉치의 카라비너로 항상 초기화
-                    if let selectedBundle = bundleVM.selectedBundle {
-                        bundleVM.newSelectedCarabiner = bundleVM.carabinerViewData.first { cbData in
-                            cbData.carabiner.id == selectedBundle.selectedCarabiner
-                        }
-                    }
-
-                    // 코인 충전 후 복귀 시 저장된 선택 복원
-                    bundleVM.restoreSelectionIfNeeded()
-                    
-                    Task {
-                        // Firebase 데이터를 한 번만 로컬 상태로 초기화
-                        await self.initializeSelectedKeyringsFromFirebase()
-                        // 이후부터는 완전히 로컬 데이터만 사용
-                        self.updateKeyringDataList()
-                        
-                        isKeyringSheetLoading = false
-                        
-                        // 씬 재구성 조건 설정
-                        if !keyringDataList.isEmpty {
-                            sceneRefreshId = UUID()
-                        }
-                    }
-                    // 키링 데이터까지 불러오고 난 후에도 키링의 개수가 0개라면 바로 씬을 준비 완료 상태로 체크
-                    if keyringDataList.isEmpty {
-                        isSceneReady = true
-                    }
-                    
-                    continuation.resume()
-                }
+        // 현재 뭉치의 배경/카라비너로 초기화
+        if let selectedBundle = bundleVM.selectedBundle {
+            bundleVM.newSelectedBackground = bundleVM.backgroundViewData.first {
+                $0.background.id == selectedBundle.selectedBackground
             }
+            bundleVM.newSelectedCarabiner = bundleVM.carabinerViewData.first {
+                $0.carabiner.id == selectedBundle.selectedCarabiner
+            }
+        }
+
+        // 코인 충전 후 복귀 시 저장된 선택 복원
+        bundleVM.restoreSelectionIfNeeded()
+
+        // Firebase 키링 데이터 초기화 (비동기)
+        Task {
+            await self.initializeSelectedKeyringsFromFirebase()
+            self.updateKeyringDataList()
+            isKeyringSheetLoading = false
+            if !keyringDataList.isEmpty {
+                sceneRefreshId = UUID()
+            }
+        }
+
+        if keyringDataList.isEmpty {
+            isSceneReady = true
         }
     }
     

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+SelectSheet.swift
@@ -56,6 +56,11 @@ extension BundleEditView {
                     viewModel: bundleVM,
                     selectedBG: bundleVM.newSelectedBackground,
                     onBackgroundTap: { bg in
+                        // 정적 배경 + 캐시 미스일 때만 로딩 표시
+                        if !bg.background.isLottie
+                            && !StorageManager.shared.isCached(path: bg.background.backgroundImage) {
+                            isBackgroundLoading = true
+                        }
                         bundleVM.newSelectedBackground = bg
                     }
                 )
@@ -103,6 +108,10 @@ extension BundleEditView {
                     }
                     bundleVM.selectedKeyrings[selectedPosition] = keyring
                     bundleVM.keyringOrder.append(selectedPosition)
+                    // 키링 바디 이미지 캐시 미스 시 로딩 표시
+                    if !StorageManager.shared.isCached(path: keyring.bodyImage) {
+                        isSceneReady = false
+                    }
                     showSelectKeyringSheet = false
                 }
                 updateKeyringDataList()

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView+SelectSheet.swift
@@ -50,27 +50,25 @@ extension BundleEditView {
     }
 
     private var itemSheetContent: some View {
-        ZStack(alignment: .top) {
-            SelectBackgroundSheet(
-                viewModel: bundleVM,
-                selectedBG: bundleVM.newSelectedBackground,
-                onBackgroundTap: { bg in
-                    bundleVM.newSelectedBackground = bg
-                }
-            )
-            .opacity(isBackgroundMode ? 1 : 0)
-            .allowsHitTesting(isBackgroundMode)
-
-            SelectCarabinerSheet(
-                viewModel: bundleVM,
-                selectedCarabiner: bundleVM.newSelectedCarabiner,
-                onCarabinerTap: { carabiner in
-                    selectCarabiner = carabiner
-                    showChangeCarabinerAlert = true
-                }
-            )
-            .opacity(isBackgroundMode ? 0 : 1)
-            .allowsHitTesting(!isBackgroundMode)
+        Group {
+            if isBackgroundMode {
+                SelectBackgroundSheet(
+                    viewModel: bundleVM,
+                    selectedBG: bundleVM.newSelectedBackground,
+                    onBackgroundTap: { bg in
+                        bundleVM.newSelectedBackground = bg
+                    }
+                )
+            } else {
+                SelectCarabinerSheet(
+                    viewModel: bundleVM,
+                    selectedCarabiner: bundleVM.newSelectedCarabiner,
+                    onCarabinerTap: { carabiner in
+                        selectCarabiner = carabiner
+                        showChangeCarabinerAlert = true
+                    }
+                )
+            }
         }
     }
     

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
@@ -24,6 +24,8 @@ struct BundleEditView<Route: BundleRoute>: View {
     @State var isKeyringSheetLoading: Bool = true
     @State var isCapturing: Bool = false
     @State var isBackgroundLoading = false
+    // 최초 씬 로딩 완료 여부 (아이템 변경 로딩과 분리)
+    @State var hasInitiallyLoaded = false
     
     // MARK: - Sheet
     @Namespace var sheetButtonNamespace
@@ -205,6 +207,7 @@ struct BundleEditView<Route: BundleRoute>: View {
                 onAllKeyringsReady: {
                     withAnimation(.easeOut(duration: 0.3)) {
                         isSceneReady = true
+                        hasInitiallyLoaded = true
                     }
                 }
             )

--- a/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Edit/BundleEditView.swift
@@ -23,6 +23,7 @@ struct BundleEditView<Route: BundleRoute>: View {
     @State var isNavigatingAway = false // 화면 전환 중인지 추적
     @State var isKeyringSheetLoading: Bool = true
     @State var isCapturing: Bool = false
+    @State var isBackgroundLoading = false
     
     // MARK: - Sheet
     @Namespace var sheetButtonNamespace
@@ -60,7 +61,7 @@ struct BundleEditView<Route: BundleRoute>: View {
     let sheetHeightRatio: CGFloat = 0.43
     
     var shouldApplyBlur: Bool {
-        showPurchaseFailAlert || showPurchaseSuccessAlert || isCapturing || !isSceneReady || bundleVM.isPurchasing
+        showPurchaseFailAlert || showPurchaseSuccessAlert || isCapturing || !isSceneReady || isBackgroundLoading || bundleVM.isPurchasing
     }
     
     var body: some View {
@@ -198,6 +199,9 @@ struct BundleEditView<Route: BundleRoute>: View {
                 carabinerWidth: carabiner.carabiner.carabinerWidth,
                 currentCarabinerType: carabiner.carabiner.type,
                 cleanupOnDisappear: true,
+                onBackgroundLoaded: {
+                    isBackgroundLoading = false
+                },
                 onAllKeyringsReady: {
                     withAnimation(.easeOut(duration: 0.3)) {
                         isSceneReady = true

--- a/Keychy/Keychy/Presentation/Bundle/Views/Shared/BackgroundCell.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Shared/BackgroundCell.swift
@@ -75,9 +75,16 @@ struct BackgroundCell: View {
                 }
             }
             // 이름 라벨
-            Text(background.background.backgroundName)
-                .typography(isSelected ? .notosans14SB : .notosans14M)
-                .foregroundStyle(isSelected ? .main500 : .black100)
+            HStack(spacing: 4) {
+                if background.background.isLottie {
+                    Image(.lottieIcon)
+                        .resizable()
+                        .frame(width: 15, height: 15)
+                }
+                Text(background.background.backgroundName)
+                    .typography(isSelected ? .notosans14SB : .notosans14M)
+                    .foregroundStyle(isSelected ? .main500 : .black100)
+            }
         }
         .contentShape(Rectangle())
     }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Shared/CarabinerCell.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Shared/CarabinerCell.swift
@@ -76,9 +76,16 @@ struct CarabinerCell: View {
                 }
             } //: ZSTACK
             .clipped()
-            Text(carabiner.carabiner.carabinerName)
-                .typography(isSelected ? .notosans14SB : .notosans14M)
-                .foregroundStyle(isSelected ? .main500 : .black100)
+            HStack(spacing: 4) {
+                if carabiner.carabiner.isLottie {
+                    Image(.lottieIcon)
+                        .resizable()
+                        .frame(width: 15, height: 15)
+                }
+                Text(carabiner.carabiner.carabinerName)
+                    .typography(isSelected ? .notosans14SB : .notosans14M)
+                    .foregroundStyle(isSelected ? .main500 : .black100)
+            }
         }
         .contentShape(Rectangle())
     }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectBackgroundSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectBackgroundSheet.swift
@@ -69,5 +69,6 @@ struct SelectBackgroundSheet: View {
             }
         }
         .padding(.horizontal, 20)
+        .padding(.bottom, 40)
     }
 }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectBackgroundSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectBackgroundSheet.swift
@@ -67,7 +67,7 @@ struct SelectBackgroundSheet: View {
                         Button {
                             onBackgroundTap(bg)
                         } label: {
-                            BackgroundCell(background: bg, isSelected: (bg == selectedBG))
+                            BackgroundCell(background: bg, isSelected: (bg == selectedBG), useThumbnail: true)
                         }
                         .buttonStyle(.plain)
                     }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectBackgroundSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectBackgroundSheet.swift
@@ -12,12 +12,7 @@ struct SelectBackgroundSheet: View {
     let selectedBG: BackgroundViewData?
     let onBackgroundTap: (BackgroundViewData) -> Void
 
-    /// 3열 그리드 컬럼 설정
-    private let gridColumns: [GridItem] = [
-        GridItem(.flexible(), spacing: 10),
-        GridItem(.flexible(), spacing: 10),
-        GridItem(.flexible(), spacing: 10)
-    ]
+    private let columnCount = 3
 
     /// 필터링 및 정렬된 배경 목록
     private var filteredAndSortedBackgrounds: [BackgroundViewData] {
@@ -56,16 +51,34 @@ struct SelectBackgroundSheet: View {
         return result
     }
 
+    /// 3열 행 단위로 분할
+    private var rows: [[BackgroundViewData]] {
+        let items = filteredAndSortedBackgrounds
+        return stride(from: 0, to: items.count, by: columnCount).map {
+            Array(items[$0..<min($0 + columnCount, items.count)])
+        }
+    }
+
     var body: some View {
-        // 그리드만 (필터바는 DraggableSheet header로 이동)
-        LazyVGrid(columns: gridColumns, spacing: 20) {
-            ForEach(filteredAndSortedBackgrounds) { bg in
-                Button {
-                    onBackgroundTap(bg)
-                } label: {
-                    BackgroundCell(background: bg, isSelected: (bg == selectedBG))
+        VStack(spacing: 20) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack(spacing: 10) {
+                    ForEach(row) { bg in
+                        Button {
+                            onBackgroundTap(bg)
+                        } label: {
+                            BackgroundCell(background: bg, isSelected: (bg == selectedBG))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    // 마지막 행이 3개 미만일 때 빈 공간 채우기
+                    if row.count < columnCount {
+                        ForEach(0..<(columnCount - row.count), id: \.self) { _ in
+                            Color.clear
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
                 }
-                .buttonStyle(.plain)
             }
         }
         .padding(.horizontal, 20)

--- a/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectCarabinerSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectCarabinerSheet.swift
@@ -12,12 +12,7 @@ struct SelectCarabinerSheet: View {
     let selectedCarabiner: CarabinerViewData?
     let onCarabinerTap: (CarabinerViewData) -> Void
 
-    /// 3열 그리드 컬럼 설정
-    private let gridColumns: [GridItem] = [
-        GridItem(.flexible(), spacing: 10),
-        GridItem(.flexible(), spacing: 10),
-        GridItem(.flexible(), spacing: 10)
-    ]
+    private let columnCount = 3
 
     /// 필터링 및 정렬된 카라비너 목록
     private var filteredAndSortedCarabiners: [CarabinerViewData] {
@@ -56,16 +51,34 @@ struct SelectCarabinerSheet: View {
         return result
     }
 
+    /// 3열 행 단위로 분할
+    private var rows: [[CarabinerViewData]] {
+        let items = filteredAndSortedCarabiners
+        return stride(from: 0, to: items.count, by: columnCount).map {
+            Array(items[$0..<min($0 + columnCount, items.count)])
+        }
+    }
+
     var body: some View {
-        // 그리드만 (필터바는 DraggableSheet header로 이동)
-        LazyVGrid(columns: gridColumns, spacing: 20) {
-            ForEach(filteredAndSortedCarabiners) { cb in
-                Button {
-                    onCarabinerTap(cb)
-                } label: {
-                    CarabinerCell(carabiner: cb, isSelected: (selectedCarabiner == cb))
+        VStack(spacing: 20) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack(spacing: 10) {
+                    ForEach(row) { cb in
+                        Button {
+                            onCarabinerTap(cb)
+                        } label: {
+                            CarabinerCell(carabiner: cb, isSelected: (selectedCarabiner == cb))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    // 마지막 행이 3개 미만일 때 빈 공간 채우기
+                    if row.count < columnCount {
+                        ForEach(0..<(columnCount - row.count), id: \.self) { _ in
+                            Color.clear
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
                 }
-                .buttonStyle(.plain)
             }
         }
         .padding(.horizontal, 20)

--- a/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectCarabinerSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectCarabinerSheet.swift
@@ -69,5 +69,6 @@ struct SelectCarabinerSheet: View {
             }
         }
         .padding(.horizontal, 20)
+        .padding(.bottom, 40)
     }
 }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectCarabinerSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Shared/SelectCarabinerSheet.swift
@@ -67,7 +67,7 @@ struct SelectCarabinerSheet: View {
                         Button {
                             onCarabinerTap(cb)
                         } label: {
-                            CarabinerCell(carabiner: cb, isSelected: (selectedCarabiner == cb))
+                            CarabinerCell(carabiner: cb, isSelected: (selectedCarabiner == cb), useThumbnail: true)
                         }
                         .buttonStyle(.plain)
                     }


### PR DESCRIPTION
> **내용이 깁니다. 하지만 중요합니다.**

## Summary
뭉치 생성/수정 화면의 배경·카라비너 시트에서 발생하던 다수의 버그를 수정하고, 
기존 메모리 캐싱 -> 디스크 캐싱을 활용하여 앱 전반의 로딩 속도를 대폭 개선했습니다.
> 기존에는 항상 파이어베이스 fetch -> 메모리에 올림이었지만, 
디스크 캐싱을 하고, 파이어스토어에서 이미지 변경이 있을 경우에만 재 캐싱합니다. 

> **배경,카라비너,키링의 경우 이미지가 파이어스토어에 있습니다.** 
**해당 이미지를 바꾸면 이미지 url이 바뀝니다.** 
**StoreManager에서 디스크 캐시를 위해 해당 url을 해쉬코드로 변환해서**
**이 값이 바뀌면 재캐싱하는 로직입니다. Alright?**

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

## 1. 배경탭 아래 빈 공간이 보이는 버그 해결

<img width="200" alt="배경탭 아래 빈공간이 보이는 버그 해결" src="https://github.com/user-attachments/assets/cfd3e441-4b93-4c68-82a0-48a769b6882a" />


### Situation
배경/카라비너 선택 시트에서 탭 전환 시, `ZStack`으로 모든 탭 콘텐츠를 동시에 쌓아두는 구조였습니다. 
비활성 탭의 높이가 활성 탭보다 짧을 경우, 아래쪽에 빈 공간이 노출되는 레이아웃 버그가 있었습니다.
> 그러니까, 배경탭이 카라비너탭보다 아이템이 적어서 발생한거죠.

### Action
- `BundleCreateView+SelectSheet`, `BundleEditView+SelectSheet`에서 `ZStack` → `if/else` 분기로 전환
- 활성 탭 콘텐츠만 뷰 트리에 포함되도록 변경
- 하단 패딩(40pt) 추가로 스크롤 끝 여백 확보

## 2. 스크롤 재로딩 버그 수정

https://github.com/user-attachments/assets/7ec02bfa-0c6c-4b32-91c2-3b2baaad4a2f

### Situation
`LazyVGrid`를 사용하고 있어 스크롤 시 화면 밖으로 나간 셀이 해제되었다가, 
다시 스크롤하면 이미지를 재로딩하는 현상이 반복되었습니다. 
특히 Lottie 아이템은 매번 다운로드 + 렌더링이 발생하여 UX가 매우 불안정했습니다.

### Task
한 번 로드된 셀이 스크롤해도 재로딩되지 않도록 해야 했습니다.

### Action
- `SelectBackgroundSheet`, `SelectCarabinerSheet`의 `LazyVGrid` 
→ 일반 `VStack` + `HStack` 기반 비Lazy 3열 그리드로 전환

> 사실 저희 시트에서 Lazy로 구현할 필요가 없습니다. 
아이템이 몇백개인거도아니고요. 어차피 시트 닫거나 탭 이동하면 메모리 해제됩니다.

> 물론 배경 -> 카라비너 -> 배경 이런 탭 전환 시, 각 아이템들 로딩표시가 나오긴합니다.
헷갈리면 안되는게, 이건 최초 로딩은 아니고 캐시에서 불러오는 로딩이라 무조건 필요합니다.

### Result
스크롤 시 이미지 재로딩 완전 제거. 모든 셀이 초기 로딩 후 즉시 표시됨

## 3. 시트 정적 이미지 + 로티 아이콘 표시

<img width="200"  alt="시트 정적이미지 + 로티아이콘" src="https://github.com/user-attachments/assets/fb63bc27-2a32-437b-b195-c04b050069a3" />

### Situation + Action
시트에서 Lottie 아이템이 실시간 애니메이션으로 재생되고 있었습니다. 
정적 이미지로 표시하되, 텍스트에 Lottie 아이템임을 구분할 수 있는 아이콘 적용.

## 4. 아이템, 키링 최초 변경 시 로딩 UX

https://github.com/user-attachments/assets/dfc668e4-64e0-46b0-98e8-e273224ad51b

https://github.com/user-attachments/assets/46e925ca-8af8-45d4-a1cb-9d4d7c65642e

### Situation
배경/카라비너를 처음 선택하면 이미지 다운로드가 필요한데, 로딩 피드백 없이 빈 화면이 잠시 노출되었습니다.
> UX 최악!!

### Task
디스크 캐시 미스(최초 로드) 시에만 로딩 Alert를 표시하고, 캐시가 있는 경우에는 즉시 전환해야 했습니다.

### Action
- `StorageManager`에 디스크 캐시 존재 여부 확인 로직 추가
- `BundleCreateView`, `BundleEditView`에서 캐시 미스일 때만 `LoadingAlert` 표시
- 캐시 히트 시에는 로딩 없이 즉시 아이템 적용

### Result
최초 선택 시에만 자연스러운 로딩 피드백 제공, 이후 선택은 즉시 반영

> 쉽게 말해서, 이번 업데이트 이후 최초 1회는 무조건 로딩걸려요. 기존처럼
#### 하지만 그 이후엔, 앱을 다시켜도 로딩 없습니다.

## 5. 시트 아이템 로딩 속도 개선

### Situation
배경/카라비너 데이터 로드와 Lottie 다운로드가 모두 순차(`for-in` + `await`)로 실행되어, 
아이템 수에 비례하여 로딩 시간이 리니어하게 증가했습니다.

### Task
독립적인 비동기 작업을 병렬로 실행하여 전체 로딩 시간을 단축해야 했습니다.

### Action
- `BundleCreateView`, `BundleEditView`의 배경/카라비너 fetch를 `async let` 병렬 실행으로 전환
- `BundleViewModel+Fetch`의 Lottie 다운로드를 `TaskGroup` 병렬 실행으로 전환

### Result
초기 시트 로딩 시간이 단축.


## 6. 앱 로딩 속도 대폭 향상 (주목)

https://github.com/user-attachments/assets/16f6d21c-aed9-4738-b86f-31cda13ba8d7

#### 자 집중하세요
위 내용을 찬찬히 읽어보셨으면, 이해하기 쉬울겁니다.

우리가 **디스크 캐시**라는 방식으로 이제 최초 로딩을 한 아이템에 대해 
디스크에서 바로 꺼내기 때문에, 로딩이 대폭 축소되었어요. 

이걸 구현하기 위해 `StoreManger`라고 하는 파이어베이스 저장소에서 
데이터를 fetch해오는 로직을 수정한겁니다. 

그런데 **키링** 역시, 결국 이미지죠? 파이어베이스 저장소에 저장되어있는.

그리고 우리 앱은, 앱을 키고 메인화면에 뭐가 나옵니까?
뭉치와 키링들이 나옵니다. 

이전 로직에서는 앱을 키면, 뭉치 + 배경 + 키링들 이미지를 쏵 다운해오는거에요. 

#### 그런데 이제? 디스크에서 꺼내는거죠! 빠를 수 밖에 없다! 

> 근데 당연하게도, 1회 fetch를 해야 빠르겠죠?
앱을 사용하면 당연히 이어지는 순서기때문에 딱히 걱정할 건 없습니다.


## 변경 파일 (14개)
```swift
// Core
- StorageManager.swift

// ViewModels
- BundleViewModel.swift
- BundleViewModel+Fetch.swift

// Views - Create
- BundleCreateView.swift
- BundleCreateView+Initialization.swift
- BundleCreateView+SelectSheet.swift

// Views - Edit
- BundleEditView.swift
- BundleEditView+Alert.swift
- BundleEditView+Initialization.swift
- BundleEditView+SelectSheet.swift

// Views - Shared
- BackgroundCell.swift
- CarabinerCell.swift
- SelectBackgroundSheet.swift
- SelectCarabinerSheet.swift
```

### 렉도 많이 줄고, 좋은 개선 한 듯합니다. 
### 그런데 큰 힘에는 큰 책임이 따르는 법이죠? 
### 버그 QA 야무지게 해봅시다 ^^

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #145  

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
