### PR TITLE
feat: 위젯 outputsize 템플릿별 조정 및 기타 qa 3종

### DIFF
--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
@@ -65,6 +65,13 @@ enum KeyringScale {
         "Nureungi": 0.6,
     ]
 
+    // MARK: - 위젯 출력 크기 (템플릿별)
+    /// 위젯 프레임 합성 후 최종 축소 크기 (px)
+    /// PNG 복잡도가 높은 템플릿은 낮춰서 30MB 제한 회피
+    private static let templateWidgetOutputSize: [String: Int] = [
+        "CrossStitch": 400
+    ]
+
     // MARK: - 위젯 바디 Y 보정값 (템플릿별)
     /// 위젯 합성 시 바디이미지 Y축 위치 보정 (음수 = 위로, 양수 = 아래로)
     private static let templateWidgetBodyOffsetY: [String: CGFloat] = [
@@ -84,6 +91,7 @@ enum KeyringScale {
     private static let defaultZoomScale: CGFloat = 1.0
     private static let defaultCarabinerScale: CGFloat = 0.65
     private static let defaultWidgetBodyOffsetY: CGFloat = 0
+    private static let defaultWidgetOutputSize: Int = 500
 
     // MARK: - Public API
 
@@ -105,5 +113,10 @@ enum KeyringScale {
     /// 위젯 합성 시 템플릿별 바디 Y 보정값 반환
     static func widgetBodyOffsetY(for template: String) -> CGFloat {
         return templateWidgetBodyOffsetY[template] ?? defaultWidgetBodyOffsetY
+    }
+
+    /// 위젯 프레임 합성 후 최종 출력 크기 반환
+    static func widgetOutputSize(for template: String) -> Int {
+        return templateWidgetOutputSize[template] ?? defaultWidgetOutputSize
     }
 }

--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
@@ -69,7 +69,8 @@ enum KeyringScale {
     /// 위젯 프레임 합성 후 최종 축소 크기 (px)
     /// PNG 복잡도가 높은 템플릿은 낮춰서 30MB 제한 회피
     private static let templateWidgetOutputSize: [String: Int] = [
-        "CrossStitch": 400
+        "CrossStitch": 400,
+        "PixelKeyring": 400
     ]
 
     // MARK: - 위젯 바디 Y 보정값 (템플릿별)

--- a/Keychy/Keychy/Core/Widget/KeyringFrameCompositor.swift
+++ b/Keychy/Keychy/Core/Widget/KeyringFrameCompositor.swift
@@ -27,8 +27,6 @@ import UniformTypeIdentifiers
 nonisolated enum KeyringFrameCompositor {
 
     static let frameSize = 1350
-    /// 위젯 출력용 크기 (1350에서 합성 후 축소하여 메모리 절약)
-    static let outputSize = 400
     static let baseFrameCount = AnimationFrameStorage.baseFrameCount
 
     /// 앱 포인트 → 1350px 프레임 픽셀 변환 스케일
@@ -157,7 +155,8 @@ nonisolated enum KeyringFrameCompositor {
                 bodyClampScale: bodyClampScale
             ) else { return nil }
 
-            // 1350 → 700 축소 (위젯 메모리 절약)
+            // 1350 → 템플릿별 크기로 축소 (위젯 메모리 절약)
+            let outputSize = KeyringScale.widgetOutputSize(for: template)
             guard let scaled = resizeSquare(composited, to: outputSize) else { return nil }
             guard let pngData = encodePNG(scaled) else { return nil }
             frames.append(pngData)

--- a/Keychy/Keychy/Presentation/Workshop/Views/Components/WorkshopItemCard.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Views/Components/WorkshopItemCard.swift
@@ -88,9 +88,9 @@ struct WorkshopItemCard<Item: WorkshopItem>: View {
                 SimpleAnimatedImage(url: item.thumbnailURL)
                     .aspectRatio(contentMode: item is Carabiner || item is KeyringTemplate ? .fit : .fill)
                     .padding(.horizontal, item is Carabiner ? 5 : 0)
-                    .padding(.vertical, item is KeyringTemplate ? 10 : 0)
-                    .clipped()
+                    .padding(.vertical, item is Carabiner || item is KeyringTemplate ? 10 : 0)
                     .frame(width: twoGridCellWidth, height: itemHeight)
+                    .clipped()
             }
 
             // 가격 오버레이


### PR DESCRIPTION
## 🎯 PR 내용
- **[위젯]** 템플릿별 outputSize 개별 조정 (CrossStitch, 픽셀 400 그외 500)
    - 기존: 전체 동일한 outputSize → 무거운 템플릿에 맞추느라 전체 화질 저하 문제가 있음.
    - 변경: `KeyringScale.widgetOutputSize(for:)`로 템플릿별 분리
- **[십자수 템플릿]** 공방 썸네일 변경 + 카라비너 셀 세로 패딩 추가
- **[배경]** 옐로 압정 제외 모두 유료 전환 (600코인)
- **[픽셀 템플릿]** description 변경

> **++ 십자수 공방 썸네일 용량이 너무커서 1mb대로 줄여서 등록 완료.**
평균 공방 썸네일 png별 용량이 300~500kb인데, 1mb가 넘는 순간 로딩이 힘들어집니다.

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
