### PR TITLE
fix: 픽셀/십자수 키링 뭉치 체인 물리 버그 및 QA 7종 수정

### DIFF
--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreGraphics
+import UIKit
 
 /// 키링 스케일 중앙 관리
 /// - 템플릿별 maxSize
@@ -79,7 +80,7 @@ enum KeyringScale {
         "Polaroid": -30,
         "AcrylicPhoto": -200,
         "ClearSketch": -180,
-        "PixelKeyring": -20,
+        "PixelKeyring": -40,
         "SpeechBubble": -60,
         "welcome": -40,
         "WishHorse26": -110,
@@ -112,7 +113,12 @@ enum KeyringScale {
     }
 
     /// 위젯 합성 시 템플릿별 바디 Y 보정값 반환
-    static func widgetBodyOffsetY(for template: String) -> CGFloat {
+    /// - bodyImage: WishHorse26 type A(기울어진) 판별용 (세로가 더 길면 type A)
+    static func widgetBodyOffsetY(for template: String, bodyImage: UIImage? = nil) -> CGFloat {
+        if template == "WishHorse26", let image = bodyImage {
+            let isTilted = image.size.height > image.size.width
+            return isTilted ? -90 : -110
+        }
         return templateWidgetBodyOffsetY[template] ?? defaultWidgetBodyOffsetY
     }
 

--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
@@ -74,6 +74,15 @@ enum KeyringScale {
         "PixelKeyring": 400
     ]
 
+    // MARK: - 위젯 바디 클램프 비율 (템플릿별)
+    /// 위젯 합성 시 바디 오버플로 방지용 최대 비율 (frameSize 대비)
+    /// 값이 클수록 바디가 크게 표시됨
+    private static let templateWidgetBodyClamp: [String: CGFloat] = [
+        "CrossStitch": 0.55,
+        "PixelKeyring": 0.55,
+        "Polaroid": 0.6
+    ]
+
     // MARK: - 위젯 바디 Y 보정값 (템플릿별)
     /// 위젯 합성 시 바디이미지 Y축 위치 보정 (음수 = 위로, 양수 = 아래로)
     private static let templateWidgetBodyOffsetY: [String: CGFloat] = [
@@ -94,6 +103,7 @@ enum KeyringScale {
     private static let defaultCarabinerScale: CGFloat = 0.65
     private static let defaultWidgetBodyOffsetY: CGFloat = 0
     private static let defaultWidgetOutputSize: Int = 500
+    private static let defaultWidgetBodyClamp: CGFloat = 0.7
 
     // MARK: - Public API
 
@@ -117,9 +127,14 @@ enum KeyringScale {
     static func widgetBodyOffsetY(for template: String, bodyImage: UIImage? = nil) -> CGFloat {
         if template == "WishHorse26", let image = bodyImage {
             let isTilted = image.size.height > image.size.width
-            return isTilted ? -90 : -110
+            return isTilted ? -100 : -120
         }
         return templateWidgetBodyOffsetY[template] ?? defaultWidgetBodyOffsetY
+    }
+
+    /// 위젯 합성 시 바디 클램프 비율 반환 (frameSize 대비)
+    static func widgetBodyClamp(for template: String) -> CGFloat {
+        return templateWidgetBodyClamp[template] ?? defaultWidgetBodyClamp
     }
 
     /// 위젯 프레임 합성 후 최종 출력 크기 반환

--- a/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
@@ -1078,14 +1078,13 @@ class MultiKeyringScene: SKScene {
             if let carabinerType = currentCarabinerType, carabinerType == .plain {
                 // Plain 타입: 첫 번째 체인 완전 고정, 나머지는 자유롭게 움직임
                 for (index, chain) in chains.enumerated() {
-                    if index == 0 {
-                        // 첫 번째 체인: 완전히 고정 (물리 비활성화)
+                    if index == 0 && chains.count > 1 {
+                        // 첫 번째 체인: 앵커 역할로 고정 (아래 체인이 있을 때만)
                         chain.physicsBody?.isDynamic = false
                     } else {
-                        // 나머지 체인들: 자유롭게 움직임
                         chain.physicsBody?.isDynamic = true
-                        chain.physicsBody?.linearDamping = 1.5
-                        chain.physicsBody?.angularDamping = 1.5
+                        chain.physicsBody?.linearDamping = chains.count == 1 ? 5.0 : 1.5
+                        chain.physicsBody?.angularDamping = chains.count == 1 ? 5.0 : 1.5
                     }
                 }
             } else {
@@ -1250,9 +1249,11 @@ class MultiKeyringScene: SKScene {
 
             // Body 근처에서만 힘 적용 (거리가 가까울수록 강한 힘)
             if distance < 50 {
+                // 체인 1개(픽셀/십자수)는 힘이 분산되지 않아 약하게 적용
+                let multiplier: CGFloat = chains.count == 1 ? 0.12 : 0.3
                 let force = CGVector(
-                    dx: velocity.dx * 0.3,
-                    dy: velocity.dy * 0.3
+                    dx: velocity.dx * multiplier,
+                    dy: velocity.dy * multiplier
                 )
 
                 // Plain 타입일 때는 Ring에도 약한 힘 적용
@@ -1277,9 +1278,10 @@ class MultiKeyringScene: SKScene {
         guard let chains = chainNodesByKeyring[index],
               let body = bodyNodes[index] else { return }
 
+        let multiplier: CGFloat = chains.count == 1 ? 0.12 : 0.3
         let force = CGVector(
-            dx: velocity.dx * 0.3,
-            dy: velocity.dy * 0.3
+            dx: velocity.dx * multiplier,
+            dy: velocity.dy * multiplier
         )
 
         // Plain 타입일 때는 Ring과 체인이 모두 찰랑거림

--- a/Keychy/Keychy/Core/Widget/KeyringFrameCompositor.swift
+++ b/Keychy/Keychy/Core/Widget/KeyringFrameCompositor.swift
@@ -121,8 +121,8 @@ nonisolated enum KeyringFrameCompositor {
         let bodyHeight = Int(templateSize.height * sceneToFrameScale)
         let bodyOffsetY = KeyringScale.widgetBodyOffsetY(for: template, bodyImage: bodyImage)
 
-        // 오버플로 방지: 바디가 피벗 아래로 매달리므로 캔버스 절반 기준으로 제한
-        let maxAllowed = CGFloat(frameSize) * 0.55
+        // 오버플로 방지: 바디가 피벗 아래로 매달리므로 캔버스 기준으로 제한
+        let maxAllowed = CGFloat(frameSize) * KeyringScale.widgetBodyClamp(for: template)
         let bodyMaxDim = max(CGFloat(bodyWidth), CGFloat(bodyHeight))
         let bodyClampScale = min(maxAllowed / bodyMaxDim, 1.0)
 

--- a/Keychy/Keychy/Core/Widget/KeyringFrameCompositor.swift
+++ b/Keychy/Keychy/Core/Widget/KeyringFrameCompositor.swift
@@ -119,7 +119,7 @@ nonisolated enum KeyringFrameCompositor {
         let templateSize = KeyringScale.maxSize(for: template)
         let bodyWidth = Int(templateSize.width * sceneToFrameScale)
         let bodyHeight = Int(templateSize.height * sceneToFrameScale)
-        let bodyOffsetY = KeyringScale.widgetBodyOffsetY(for: template)
+        let bodyOffsetY = KeyringScale.widgetBodyOffsetY(for: template, bodyImage: bodyImage)
 
         // 오버플로 방지: 바디가 피벗 아래로 매달리므로 캔버스 절반 기준으로 제한
         let maxAllowed = CGFloat(frameSize) * 0.55

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/CrossStitch/ViewModels/CrossStitchVM+ImageConversion.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/CrossStitch/ViewModels/CrossStitchVM+ImageConversion.swift
@@ -102,7 +102,7 @@ extension CrossStitchVM {
         let frameH = frameImage.size.height
         let aspectRatio = frameH > 0 ? frameW / frameH : 1.0
 
-        let canvasH: CGFloat = 200
+        let canvasH: CGFloat = 258
         let canvasW: CGFloat = canvasH * aspectRatio
         let canvasSize = CGSize(width: canvasW, height: canvasH)
 

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/CrossStitch/ViewModels/CrossStitchVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/CrossStitch/ViewModels/CrossStitchVM.swift
@@ -155,7 +155,6 @@ class CrossStitchVM: KeyringViewModelProtocol {
 
     private func saveToUndoStack() {
         undoStack.append(stitchGrid)
-        if undoStack.count > 50 { undoStack.removeFirst() }
     }
 
     func undo() {

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/CrossStitch/Views/CrossStitchDrawView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/CrossStitch/Views/CrossStitchDrawView.swift
@@ -13,6 +13,7 @@ struct CrossStitchDrawView: View {
 
     @State private var showResetAlert = false
     @State private var isResetting = false
+    @State private var swipeDisabled = false
 
     /// 줌/패닝 상태
     @State private var scale: CGFloat = 1.0
@@ -72,6 +73,14 @@ struct CrossStitchDrawView: View {
         .ignoresSafeArea()
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled(true)
+        .swipeBackGesture(enabled: !swipeDisabled)
+        .onAppear {
+            // sheet 닫힘 후 Preview의 swipeBackGesture(enabled: true)가
+            // 덮어쓰는 타이밍 이슈 방지를 위해 onAppear에서 state 변경으로 재트리거
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                swipeDisabled = true
+            }
+        }
         .alert("작업을 취소하시겠습니까?", isPresented: $showResetAlert) {
             Button("취소", role: .cancel) { }
             Button("확인", role: .destructive) {

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Pixel/ViewModels/PixelVM+ImageConversion.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Pixel/ViewModels/PixelVM+ImageConversion.swift
@@ -49,7 +49,7 @@ extension PixelVM {
     /// 픽셀 이미지와 프레임 이미지를 합성
     func composeWithFrame(pixelImage: UIImage, frameImage: UIImage) -> UIImage {
         // 캔버스 크기를 키워서 프레임 이동 시 잘리지 않도록
-        let targetSize: CGFloat = 200
+        let targetSize: CGFloat = 277
         let frameOffsetX: CGFloat = 2.0 // 프레임을 오른쪽으로 2 이동
         let canvasWidth: CGFloat = targetSize + frameOffsetX // 오른쪽만 여유
         let finalSize = CGSize(width: canvasWidth, height: targetSize)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Pixel/ViewModels/PixelVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Pixel/ViewModels/PixelVM.swift
@@ -158,11 +158,6 @@ class PixelVM: KeyringViewModelProtocol {
     /// Undo 스택에 현재 상태 저장
     private func saveToUndoStack() {
         undoStack.append(pixelGrid)
-
-        // 최대 50개까지만 저장
-        if undoStack.count > 50 {
-            undoStack.removeFirst()
-        }
     }
 
     /// Undo

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Pixel/Views/PixelDrawView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Pixel/Views/PixelDrawView.swift
@@ -14,7 +14,8 @@ struct PixelDrawView: View {
     /// 팔레트 표시 여부 (그리기 모드일 때만 표시)
     @State private var showPalette: Bool = true
     @State private var showResetAlert = false
-    
+    @State private var swipeDisabled = false
+
     /// 화면 사라지기 전 그리드 렌더링 막기용 파라미터
     @State private var isResetting = false
     
@@ -82,6 +83,12 @@ struct PixelDrawView: View {
         .ignoresSafeArea()
         .navigationBarBackButtonHidden(true)
         .interactiveDismissDisabled(true)
+        .swipeBackGesture(enabled: !swipeDisabled)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                swipeDisabled = true
+            }
+        }
         .alert("작업을 취소하시겠습니까?", isPresented: $showResetAlert) {
             Button("취소", role: .cancel) { }
             Button("확인", role: .destructive) {


### PR DESCRIPTION
<!-- 아래 내용은 기본적으로 지켜주세요! -->
<!-- 섹션은 마음대로 추가해도 됩니다! -->

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 1. 픽셀/십자수 키링 뭉치에서 인터랙션 안되던 버그

**문제**: 픽셀/십자수 템플릿(단일 체인)에서 인터랙션 불가 현상 발생.

**원인**: 플레인 타입의 첫 번째 체인이 앵커(고정점)로 설계되어 있어, 단일 체인 템플릿에서는 움직일 수 있는 객체가 없었음.

**해결**: 템플릿 타입에 따른 isDynamic 조건 보정 및 힘 배율(0.12) 최적화로 단일 체인 물리 구현.

### 2. 픽셀/십자수 키링, 드로우뷰 제스처 간섭 차단

Sheet 닫힘 타이밍 이슈를 해결하기 위해 드로잉 구간 내 스와이프 백(뒤로가기 제스처) 비활성화.

### 3. 기능 확장 및 렌더링 최적화
**Undo 제한 해제**: Pixel/CrossStitch 템플릿의 Undo 횟수 제한(50회)을 제거하여 무제한 작업 지원.

**픽/십 키링 이미지 합성 비율 정밀화**: bodyImage 합성 시 각 템플릿별 maxSize에 맞춰 비율 수정 (Pixel: 277, CrossStitch: 258).
(픽/십 키링은 완성뷰 이미지저장과 보관함 이미지 저장 사이즈가 달랐음.)

**템플릿별 위젯 바디 클램프 분리**: 원래 모든 템플릿이 글로벌 설정값(0.55)으로 바디 크기가 결정되었는데, 
템플릿별 간극이 커서 템플릿별 바디 크기 지정 로직 구현 

> CrossStitch/Pixel: 0.55 / Polaroid: 0.6 / 기타: 0.7

> 위 작업에 따른, 템플릿별 yOffset 수정 완료.

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #155 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
