### PR TITLE
perf: Nuke DataCache 통합으로 이미지 캐시 시스템 일원화

### DIFF
--- a/Keychy/Keychy/App/KeychyApp.swift
+++ b/Keychy/Keychy/App/KeychyApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Nuke
 
 /// Keychy 앱의 진입점
 /// - AppDelegate를 통해 Firebase, Push 알림 등의 초기 설정 수행
@@ -17,6 +18,18 @@ struct KeychyApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     init() {
+        // Nuke DataCache 활성화 (HTTP 헤더 무시, 무조건 디스크 저장)
+        ImagePipeline.shared = ImagePipeline(configuration: .withDataCache)
+
+        // 기존 StorageManager 디스크 캐시 → Nuke DataCache 마이그레이션 (1회성)
+        let migrationKey = "didMigrateToNukeDataCache"
+        if !UserDefaults.standard.bool(forKey: migrationKey) {
+            let oldCacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("StorageImageCache")
+            try? FileManager.default.removeItem(at: oldCacheDir)
+            UserDefaults.standard.set(true, forKey: migrationKey)
+        }
+
         // 네트워크 모니터링 시작
         NetworkManager.shared.startMonitoring()
 

--- a/Keychy/Keychy/Core/Firebase/StorageManager.swift
+++ b/Keychy/Keychy/Core/Firebase/StorageManager.swift
@@ -7,21 +7,11 @@
 
 import SwiftUI
 import FirebaseStorage
-import CryptoKit
+import Nuke
 
-@Observable
 class StorageManager {
-    
-    static let shared = StorageManager()
-    
-    private var imageCache: [String: UIImage] = [:]
-    private let cacheQueue = DispatchQueue(label: "com.keychy.storageCache", attributes: .concurrent)
 
-    // iOS가 저장공간 부족 시 자동 정리해주는 cachesDirectory 사용
-    private var diskCacheDirectory: URL {
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-        return cacheDir.appendingPathComponent("StorageImageCache")
-    }
+    static let shared = StorageManager()
 
     private init() {}
     
@@ -36,127 +26,19 @@ class StorageManager {
         return data
     }
     
-    // MARK: - URL에서 이미지 가져오기
-    // 로드 순서: 메모리 캐시 → 디스크 캐시 → 네트워크
+    // MARK: - 이미지 로드 (Nuke 파이프라인)
+    // 메모리 캐시 → DataCache(디스크) → 네트워크 순서로 자동 처리
     func getImage(path: String) async throws -> UIImage {
-        // 1) 메모리 캐시 확인 (즉시)
-        if let cachedImage = getCachedImage(for: path) {
-            return cachedImage
+        guard let url = URL(string: path) else {
+            throw URLError(.badURL)
         }
-
-        // 2) 디스크 캐시 확인 (~5ms)
-        if let diskImage = getDiskCachedImage(for: path) {
-            setCachedImage(diskImage, for: path)
-            return diskImage
-        }
-
-        // 3) 네트워크 다운로드 → 메모리 + 디스크 캐시 저장
-        let data = try await getData(path: path)
-
-        guard let image = UIImage(data: data) else {
-            print("이미지 변환 실패: \(path)")
-            throw URLError(.badServerResponse)
-        }
-
-        setCachedImage(image, for: path)
-        saveToDiskCache(data, for: path)
-
-        return image
-    }
-    
-    func getMultipleImages(paths: [String]) async throws -> [String: UIImage] {
-        
-        return try await withThrowingTaskGroup(of: (String, UIImage).self) { group in
-            var images: [String: UIImage] = [:]
-            
-            for path in paths {
-                group.addTask {
-                    let image = try await self.getImage(path: path)
-                    return (path, image)
-                }
-            }
-            
-            for try await (path, image) in group {
-                images[path] = image
-            }
-            
-            return images
-        }
-    }
-    
-    // MARK: - 캐시 관리 (수정 예정)
-    private func getCachedImage(for path: String) -> UIImage? {
-        cacheQueue.sync {
-            return imageCache[path]
-        }
-    }
-    
-    private func setCachedImage(_ image: UIImage, for path: String) {
-        cacheQueue.async(flags: .barrier) {
-            self.imageCache[path] = image
-        }
-    }
-    
-    // 특정 이미지 캐시 삭제 (메모리 + 디스크)
-    func removeCachedImage(for path: String) {
-        cacheQueue.async(flags: .barrier) {
-            self.imageCache.removeValue(forKey: path)
-        }
-        removeDiskCachedImage(for: path)
+        return try await ImagePipeline.shared.image(for: url)
     }
 
-    // 전체 캐시 삭제 (메모리 + 디스크)
-    func clearCache() {
-        cacheQueue.async(flags: .barrier) {
-            self.imageCache.removeAll()
-        }
-        clearDiskCache()
-    }
-
-    /// 메모리 캐시 또는 디스크 캐시에 해당 path의 이미지가 존재하는지 동기적으로 확인
+    /// Nuke 메모리 캐시 + DataCache(디스크)에 이미지가 존재하는지 동기적으로 확인
     func isCached(path: String) -> Bool {
-        if getCachedImage(for: path) != nil { return true }
-        let fileURL = diskCacheDirectory.appendingPathComponent(diskCacheKey(for: path))
-        return FileManager.default.fileExists(atPath: fileURL.path)
-    }
-
-    // MARK: - 디스크 캐시
-
-    /// URL → SHA256 해시 문자열 (파일명으로 안전하게 사용 가능)
-    private func diskCacheKey(for path: String) -> String {
-        let digest = SHA256.hash(data: Data(path.utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
-    }
-
-    /// 디스크에서 이미지 읽기
-    private func getDiskCachedImage(for path: String) -> UIImage? {
-        let fileURL = diskCacheDirectory.appendingPathComponent(diskCacheKey(for: path))
-        guard let data = try? Data(contentsOf: fileURL),
-              let image = UIImage(data: data) else {
-            return nil
-        }
-        return image
-    }
-
-    /// 원본 Data를 디스크에 저장 (백그라운드에서 실행)
-    private func saveToDiskCache(_ data: Data, for path: String) {
-        let dir = diskCacheDirectory
-        let fileURL = dir.appendingPathComponent(diskCacheKey(for: path))
-        DispatchQueue.global(qos: .utility).async {
-            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            try? data.write(to: fileURL, options: .atomic)
-        }
-    }
-
-    /// 개별 디스크 캐시 삭제
-    private func removeDiskCachedImage(for path: String) {
-        let fileURL = diskCacheDirectory.appendingPathComponent(diskCacheKey(for: path))
-        try? FileManager.default.removeItem(at: fileURL)
-    }
-
-    /// 전체 디스크 캐시 삭제
-    private func clearDiskCache() {
-        try? FileManager.default.removeItem(at: diskCacheDirectory)
+        guard let url = URL(string: path) else { return false }
+        return ImagePipeline.shared.cache.containsCachedImage(for: ImageRequest(url: url))
     }
 
     // MARK: - 업로드


### PR DESCRIPTION
## 배경 (이거만 이해해도 좋습니다.)


우리앱은 정적인 이미지가 참 많은데, 
**그러한 데이터들을 항상 파이어베이스에서 fetch**하고 있었습니다. (그러니까 로딩이 매번 있는거죠)
그래서 **앱을 키면 최초 1회 fetch를 무조건 해야하고**.
그로인한 **사용성 저하가 심각**했죠.

그런데 정적인 이미지인데 왜 항상 fetch해야할까요?
그러니, 정적인 이미지는 사용자 로컬디스크에 넣어두고 쓰면 되는겁니다.  
이번에 그러한 구현을 한 것입니다.

**물론 변동에 대한 대응도 됩니다.** 

> 예를들면, 
십자수 공방 썸네일을 A라는걸 쓴다고 합시다.
사용자는 이 썸네일 A를 1회 fetch하고 쭉 사용합니다. 

> 그러다가, 디자이너의 개선으로 썸네일을 B로 바꿉니다. 
그러면 이미지 URL이 바뀌었기때문에 앱에서는 이 썸네일을 재 fetch합니다.


## 좀 더 자세한 문제상황들
- 같은 이미지를 Nuke와 StorageManager가 각각 따로 다운로드하는 경우도 있고.
- `ImagePrefetcher`로 미리 받아놔도 SpriteKit 씬에서 못 찾고 다시 다운로드. 
(약간 코인거래를 하는데 거래소를 다른데서 써서 지갑이 달라. 그래서 동기화 될 수가 없는 느낌이랄까)
- StorageManager 메모리 캐시의 문제는 `[String: UIImage]` 딕셔너리 무한 적재 (LRU 없음, Nuke는 자체로 해주니까)
> 가장 큰 이유는, 일단 캐시 관련 로직 정리를 한 적이 없어서 레거시 코드도 마구마구 있었음.
> **그리고 앱 전체적인 최적화가 가장 큰 목적!**


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

<img width="300" alt="키치 로컬 데이터 사용 사진" src="https://github.com/user-attachments/assets/5cee329a-14ef-4439-93a3-f292a69b2fb8" />

원래는 항상 앱 메모리에서만 놀아서, 앱을 끄면 휘발되었지만 
이제는 디스크에 캐싱을 하기에, 앱 자체 데이터가 늘어나는 모습! 

> 쉽게 생각해보면, 카카오톡 같은거 오래쓰면 막 용량 몇기가 되어있잖아 그런 느낌인거지
이렇게 해야 정적인 데이터는 바로바로 보여줄 수 있고. 
**굳이 파이어베이스 요청 쿼리를 안날려도 되니까 비용 절감 효과가 엄청날 것임.**

## 변경 후

```
  [LazyImage + SpriteKit + 전부]  →  Nuke (DataCache 활성화)
                                      ├─ 메모리 캐시: LRU 자동 관리해줌
                                      └─ 디스크 캐시: HTTP 헤더 무시, 무조건 저장함
```

StorageManager는 이미지 캐시를 버리고 **업로드/삭제만 담당**합니다.

> 이제 Nuke 라이브러리를 효율 좋게 사용할 수 있게 되었다.

### `KeychyApp.swift` — Nuke DataCache 활성화 (핵심)

```swift
ImagePipeline.shared = ImagePipeline(configuration: .withDataCache)
```

`ImagePipeline`은 Nuke의 이미지 로딩 엔진입니다. 
`.shared`는 싱글톤 패턴 — 앱 전체에서 하나의 파이프라인을 공유합니다.

`.withDataCache`는 Nuke가 제공하는 프리셋 Configuration으로, 
**내부적으로 DataCache 객체를 생성해서 디스크 캐시를 활성화합니다.** 
**기본 Nuke는 URLCache(HTTP 헤더 의존)만 쓰는데, DataCache는 HTTP 헤더를 무시하고 무조건 디스크에 저장합니다.**

**이 1줄로 앱 전체의 LazyImage, ImagePrefetcher, ImagePipeline.shared.image(for:) 전부 디스크 캐싱이 적용됩니다.**


```swift
// 기존 StorageManager 디스크 캐시 → Nuke DataCache 마이그레이션 (1회성)
let migrationKey = "didMigrateToNukeDataCache"
if !UserDefaults.standard.bool(forKey: migrationKey) {
   let oldCacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
		.appendingPathComponent("StorageImageCache")
	try? FileManager.default.removeItem(at: oldCacheDir)
	UserDefaults.standard.set(true, forKey: migrationKey)
        }
```

기존 캐시데이터 지우는 코드!

**첫 실행**: DataCache 활성화 → 기존 캐시 삭제 → 플래그 저장
**다음부터**: DataCache 활성화 → (플래그 true라 건너뜀)

## 기존 유저 영향
- 앱 업데이트 후 첫 실행 시 이미지 1회 재다운로드 (기존 디스크 캐시 삭제됨)
- 이후 Nuke DataCache에 저장되어 즉시 로드
- 기존에도 iOS 캐시 정리 시 동일 상황 → 로딩 Alert로 이미 대응됨
> 쉽게 말해서, 앱키고 원래 렉걸리던거 있잖아요
그거 1회만 받고 평생 안받는 것임.
물론 새로운 아이템이나, 데이터 변경 등에는 당연한 로딩이 있는 것이구요.

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #149 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
