### PR TITLE
feat: Debug/TestFlight 환경에서 isActive 필터 비활성화 적용

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 		4CC8D0202EF0447100317467 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC8D01E2EF0447100317467 /* MyPageViewModel.swift */; };
 		4CC8D0222EF110A300317467 /* NotificationGiftViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC8D0212EF110A300317467 /* NotificationGiftViewModel.swift */; };
 		4CC8D0252EF11CD200317467 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC8D0242EF11CD200317467 /* HomeViewModel.swift */; };
+		4CC9E5112F67B7EA00491EE4 /* BuildEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC9E5102F67B7EA00491EE4 /* BuildEnvironment.swift */; };
 		4CEBB1482EFA93D000CF53E2 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEBB1462EFA93D000CF53E2 /* RootView.swift */; };
 		4CEBB1492EFA93D000CF53E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEBB1442EFA93D000CF53E2 /* AppDelegate.swift */; };
 		4CEBB14D2EFAA52F00CF53E2 /* DeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEBB14A2EFAA52F00CF53E2 /* DeepLinkHandler.swift */; };
@@ -1030,6 +1031,7 @@
 		4CC8D01E2EF0447100317467 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		4CC8D0212EF110A300317467 /* NotificationGiftViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationGiftViewModel.swift; sourceTree = "<group>"; };
 		4CC8D0242EF11CD200317467 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		4CC9E5102F67B7EA00491EE4 /* BuildEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildEnvironment.swift; sourceTree = "<group>"; };
 		4CEBB1442EFA93D000CF53E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4CEBB1462EFA93D000CF53E2 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		4CEBB14A2EFAA52F00CF53E2 /* DeepLinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkHandler.swift; sourceTree = "<group>"; };
@@ -2572,6 +2574,7 @@
 		4CEC62182EAE08DA0099ECEE /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				4CC9E5102F67B7EA00491EE4 /* BuildEnvironment.swift */,
 				4CF2A9692F0B94EA00BA9FDA /* View+PullToRefresh.swift */,
 				4CA9C6A72EC9DB5300CA546B /* View+SafeAreaBottom.swift */,
 				4CEC62162EAE08DA0099ECEE /* UIImage+Extension.swift */,
@@ -3477,6 +3480,7 @@
 				4CF2A96D2F0F969300BA9FDA /* UpdateAlert.swift in Sources */,
 				4C7775322EB0EEF100981C3E /* ItemDetailImage.swift in Sources */,
 				AA0213F12F0E000000000001 /* TemplateImageSlideshow.swift in Sources */,
+				4CC9E5112F67B7EA00491EE4 /* BuildEnvironment.swift in Sources */,
 				AA2146B12F15D43C0048D40E /* BundleEditView+Alert.swift in Sources */,
 				4C07024C2ECF10760026D6DC /* EffectSyncManager.swift in Sources */,
 				4C25259C2F303745003CC5AD /* WidgetBundleModel.swift in Sources */,
@@ -3767,7 +3771,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BUKGH5MWAT;
 				ENABLE_PREVIEWS = YES;
@@ -3788,7 +3792,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3816,7 +3820,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BUKGH5MWAT;
 				ENABLE_PREVIEWS = YES;
@@ -3837,7 +3841,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3865,7 +3869,7 @@
 				CODE_SIGN_ENTITLEMENTS = WidgetKeychy/WidgetKeychyExtension.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BUKGH5MWAT;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3877,7 +3881,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app.WidgetKeychy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3908,7 +3912,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BUKGH5MWAT;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3920,7 +3924,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.3;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app.WidgetKeychy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Keychy/Keychy/App/AppDelegate.swift
+++ b/Keychy/Keychy/App/AppDelegate.swift
@@ -55,6 +55,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Firebase 초기화
         FirebaseApp.configure()
 
+        // 빌드 환경 판별 (Debug/TestFlight vs App Store)
+        Task { await BuildEnvironment.configure() }
+
         // TabBar 외형 설정
         configureTabBarAppearance()
 

--- a/Keychy/Keychy/Core/Extensions/BuildEnvironment.swift
+++ b/Keychy/Keychy/Core/Extensions/BuildEnvironment.swift
@@ -1,0 +1,50 @@
+//
+//  BuildEnvironment.swift
+//  Keychy
+//
+//  Created by 길지훈 on 2026-03-13.
+//
+
+import StoreKit
+import FirebaseFirestore
+
+/// 빌드 환경 판별 유틸리티
+/// - Debug / TestFlight: isTestEnvironment == true → isActive 무시하고 전체 아이템 표시
+/// - App Store (프로덕션): isTestEnvironment == false → isActive == true 아이템만 표시
+///
+/// AppTransaction.environment 값:
+/// - .xcode → Simulator / 디바이스 Debug
+/// - .sandbox → TestFlight
+/// - .production → App Store
+enum BuildEnvironment {
+    private(set) static var isTestEnvironment: Bool = {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }()
+
+    /// 앱 시작 시 호출. Release 빌드에서 TestFlight 여부를 확인하여 캐싱.
+    static func configure() async {
+        #if !DEBUG
+        guard let result = try? await AppTransaction.shared,
+              case .verified(let transaction) = result else { return }
+        isTestEnvironment = transaction.environment != .production
+        #endif
+
+        print("[BuildEnvironment] isTestEnvironment: \(isTestEnvironment)")
+    }
+}
+
+// MARK: - Firestore isActive 필터 헬퍼
+extension CollectionReference {
+    /// 테스트 환경(Debug/TestFlight)에서는 전체 문서, 프로덕션에서는 isActive == true만 반환
+    func activeItems() async throws -> QuerySnapshot {
+        if BuildEnvironment.isTestEnvironment {
+            return try await getDocuments()
+        } else {
+            return try await whereField("isActive", isEqualTo: true).getDocuments()
+        }
+    }
+}

--- a/Keychy/Keychy/Core/Firebase/WorkshopDataManager.swift
+++ b/Keychy/Keychy/Core/Firebase/WorkshopDataManager.swift
@@ -114,13 +114,7 @@ class WorkshopDataManager {
         do {
             let collectionRef = Firestore.firestore().collection(collection)
 
-            // isActive 필터 적용 (모든 컬렉션)
-            #if DEBUG
-            let snapshot = try await collectionRef.getDocuments()
-            #else
-            let snapshot = try await collectionRef.whereField("isActive", isEqualTo: true).getDocuments()
-            #endif
-
+            let snapshot = try await collectionRef.activeItems()
 
             let items = try snapshot.documents.compactMap { document in
                 try document.data(as: T.self)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/AcrylicPhoto/ViewModels/AcrylicPhotoVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/AcrylicPhoto/ViewModels/AcrylicPhotoVM.swift
@@ -201,8 +201,7 @@ class AcrylicPhotoVM: KeyringViewModelProtocol {
             // Sound 전체 가져오기 (isActive == true만)
             let soundsSnapshot = try await Firestore.firestore()
                 .collection("Sound")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allSounds = try soundsSnapshot.documents.compactMap {
                 try $0.data(as: Sound.self)
@@ -224,8 +223,7 @@ class AcrylicPhotoVM: KeyringViewModelProtocol {
             // Particle 전체 가져오기 (isActive == true만)
             let particlesSnapshot = try await Firestore.firestore()
                 .collection("Particle")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allParticles = try particlesSnapshot.documents.compactMap {
                 try $0.data(as: Particle.self)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/ClearSketch/ViewModels/ClearSketchVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/ClearSketch/ViewModels/ClearSketchVM.swift
@@ -168,8 +168,7 @@ class ClearSketchVM: KeyringViewModelProtocol {
             // Sound 전체 가져오기 (isActive == true만)
             let soundsSnapshot = try await Firestore.firestore()
                 .collection("Sound")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allSounds = try soundsSnapshot.documents.compactMap {
                 try $0.data(as: Sound.self)
@@ -191,8 +190,7 @@ class ClearSketchVM: KeyringViewModelProtocol {
             // Particle 전체 가져오기 (isActive == true만)
             let particlesSnapshot = try await Firestore.firestore()
                 .collection("Particle")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allParticles = try particlesSnapshot.documents.compactMap {
                 try $0.data(as: Particle.self)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/CrossStitch/ViewModels/CrossStitchVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/CrossStitch/ViewModels/CrossStitchVM.swift
@@ -220,8 +220,7 @@ class CrossStitchVM: KeyringViewModelProtocol {
             // Sound 전체 가져오기
             let soundsSnapshot = try await Firestore.firestore()
                 .collection("Sound")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allSounds = try soundsSnapshot.documents.compactMap {
                 try $0.data(as: Sound.self)
@@ -241,8 +240,7 @@ class CrossStitchVM: KeyringViewModelProtocol {
             // Particle 전체 가져오기
             let particlesSnapshot = try await Firestore.firestore()
                 .collection("Particle")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allParticles = try particlesSnapshot.documents.compactMap {
                 try $0.data(as: Particle.self)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/DuZzonKu/ViewModels/DuZzonKuVM+Firebase.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/DuZzonKu/ViewModels/DuZzonKuVM+Firebase.swift
@@ -39,8 +39,7 @@ extension DuZzonKuVM {
             // Sound 전체 가져오기
             let soundsSnapshot = try await Firestore.firestore()
                 .collection("Sound")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
             
             let allSounds = try soundsSnapshot.documents.compactMap {
                 try $0.data(as: Sound.self)
@@ -60,8 +59,7 @@ extension DuZzonKuVM {
             // Particle 전체 가져오기
             let particlesSnapshot = try await Firestore.firestore()
                 .collection("Particle")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
             
             let allParticles = try particlesSnapshot.documents.compactMap {
                 try $0.data(as: Particle.self)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Pixel/ViewModels/PixelVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Pixel/ViewModels/PixelVM.swift
@@ -234,8 +234,7 @@ class PixelVM: KeyringViewModelProtocol {
             // Sound 전체 가져오기
             let soundsSnapshot = try await Firestore.firestore()
                 .collection("Sound")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allSounds = try soundsSnapshot.documents.compactMap {
                 try $0.data(as: Sound.self)
@@ -255,8 +254,7 @@ class PixelVM: KeyringViewModelProtocol {
             // Particle 전체 가져오기
             let particlesSnapshot = try await Firestore.firestore()
                 .collection("Particle")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allParticles = try particlesSnapshot.documents.compactMap {
                 try $0.data(as: Particle.self)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Polaroid/ViewModels/PolaroidVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Polaroid/ViewModels/PolaroidVM.swift
@@ -162,8 +162,7 @@ class PolaroidVM: KeyringViewModelProtocol {
             // Sound 전체 가져오기
             let soundsSnapshot = try await Firestore.firestore()
                 .collection("Sound")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allSounds = try soundsSnapshot.documents.compactMap {
                 try $0.data(as: Sound.self)
@@ -183,8 +182,7 @@ class PolaroidVM: KeyringViewModelProtocol {
             // Particle 전체 가져오기
             let particlesSnapshot = try await Firestore.firestore()
                 .collection("Particle")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
 
             let allParticles = try particlesSnapshot.documents.compactMap {
                 try $0.data(as: Particle.self)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/SpeechBubble/ViewModels/SpeechBubbleVM+Firebase.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/SpeechBubble/ViewModels/SpeechBubbleVM+Firebase.swift
@@ -40,8 +40,7 @@ extension SpeechBubbleVM {
             // Sound 전체 가져오기
             let soundsSnapshot = try await Firestore.firestore()
                 .collection("Sound")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
             
             let allSounds = try soundsSnapshot.documents.compactMap {
                 try $0.data(as: Sound.self)
@@ -61,8 +60,7 @@ extension SpeechBubbleVM {
             // Particle 전체 가져오기
             let particlesSnapshot = try await Firestore.firestore()
                 .collection("Particle")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
             
             let allParticles = try particlesSnapshot.documents.compactMap {
                 try $0.data(as: Particle.self)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/WishHorse26/ViewModels/WishHorse26VM+Firebase.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/WishHorse26/ViewModels/WishHorse26VM+Firebase.swift
@@ -39,8 +39,7 @@ extension WishHorse26VM {
             // Sound 전체 가져오기
             let soundsSnapshot = try await Firestore.firestore()
                 .collection("Sound")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
             
             let allSounds = try soundsSnapshot.documents.compactMap {
                 try $0.data(as: Sound.self)
@@ -60,8 +59,7 @@ extension WishHorse26VM {
             // Particle 전체 가져오기
             let particlesSnapshot = try await Firestore.firestore()
                 .collection("Particle")
-                .whereField("isActive", isEqualTo: true)
-                .getDocuments()
+                .activeItems()
             
             let allParticles = try particlesSnapshot.documents.compactMap {
                 try $0.data(as: Particle.self)


### PR DESCRIPTION
## 배경
  - 기존 `#if DEBUG`로는 TestFlight(Release 빌드)에서 비활성 아이템 테스트 불가
  - 비개발자 팀원들이 TestFlight에서 신규 아이템을 확인할 수 없는 문제

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

- `AppTransaction` 기반 `BuildEnvironment` 유틸리티 추가 (Debug/TestFlight vs App Store 런타임 판별)
    > 기존 `appStoreReceiptURL`이 iOS 18부터 deprecated되었길래, StoreKit의 `AppTransaction.environment` 사용.
    > `#if DEBUG`는 컴파일 타임에 결정되어 코드 블록 자체가 포함/제외되지만, 
    TestFlight 여부는 동일한 Release 바이너리가 어떤 환경에서 실행되느냐에 따라 달라지므로 런타임 판별이 필요하다고 함.
    
- `CollectionReference.activeItems()` 헬퍼로 isActive 쿼리 분기를 한 곳에서 관리
	> 테스트 환경에서는 전체 문서 반환, 프로덕션에서는 `isActive == true`만 반환. 
	조금 복잡할거같아서, 헬퍼 함수 만들어서 각 호출부에서 조건문 없이 한 줄로 적용.
	
- `WorkshopDataManager` + 템플릿 VM 8개 일괄 적용
	> `WorkshopDataManager`의 `#if DEBUG` 분기 제거, 8개 템플릿 VM의 `.whereField("isActive", isEqualTo: true).getDocuments()` → `.activeItems()` 교체.

## 동작
  | 환경 | `isTestEnvironment` | 비활성 아이템 노출 |
  |------|:---:|:---:|
  | Debug | `true` | O |
  | TestFlight | `true` | O |
  | App Store | `false` | X |

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
<img width="200" alt="앱스토어" src="https://github.com/user-attachments/assets/e41e0f9b-bdaa-4092-a11a-5932011b2071" />
<img width="200" alt="테플" src="https://github.com/user-attachments/assets/ab4424f0-9d34-4be9-b6ee-35d21ebe800a" />
<img width="200" alt="디버ㅐ그" src="https://github.com/user-attachments/assets/ede63287-7720-4167-a264-8c4d0d29bebc" />

> 좌측부터, 앱스토어 / 테플 / 디버그 환경 

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #159 

https://giljihun.tistory.com/4 
> 위에 조금 더 자세하게 썼으니, 리엘 궁금하시면 확인해보세요

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
