### PR TITLE
perf: 뭉치 스와이프 힘을 bundleScale에 비례하도록 조정

### DIFF
--- a/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
@@ -1256,7 +1256,9 @@ class MultiKeyringScene: SKScene {
 
             // Body 근처에서만 힘 적용 (거리가 가까울수록 강한 힘)
             if distance < 50 {
-                let multiplier: CGFloat = 0.3
+                // 스케일이 작을수록 impulse도 비례하여 줄여 과도한 회전/이탈 방지
+                let bundleScale = KeyringScale.bundleKeyringScale(for: carabinerId)
+                let multiplier: CGFloat = 0.3 * bundleScale
                 let force = CGVector(
                     dx: velocity.dx * multiplier,
                     dy: velocity.dy * multiplier
@@ -1284,7 +1286,9 @@ class MultiKeyringScene: SKScene {
         guard let chains = chainNodesByKeyring[index],
               let body = bodyNodes[index] else { return }
 
-        let multiplier: CGFloat = 0.3
+        // 스케일이 작을수록 impulse도 비례하여 줄여 과도한 회전/이탈 방지
+        let bundleScale = KeyringScale.bundleKeyringScale(for: carabinerId)
+        let multiplier: CGFloat = 0.3 * bundleScale
         let force = CGVector(
             dx: velocity.dx * multiplier,
             dy: velocity.dy * multiplier


### PR DESCRIPTION
## 배경

뭉치에서 카라비너별 키링 스케일(0.5~0.7)이 적용될 때, 
스와이프 시 가해지는 impulse가 고정값이라 스케일이 작은 키링이 과도하게 회전/이탈하는 문제 발발 ~

스와이프 힘의 `multiplier`가 **고정값 0.3**으로, 
`bundleScale`과 무관하게 동일한 impulse가 적용되고 있었습니다.

**물리 바디 크기는 스케일에 따라 줄어드는데 impulse는 그대로니까, 작은 물체에 큰 힘이 가해지는 셈**입니다.

> 쉽게 말해 — 볼링공과 탁구공에 똑같은 힘으로 밀면 탁구공이 훨씬 멀리 날아가는 것과 같은 원리입니다.
> 스케일 0.5 키링(탁구공)과 0.7 키링(볼링공)에 동일한 0.3의 힘을 주니, 작은 키링이 과도하게 튕겨나갔습니다.

## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

`multiplier`에 `bundleScale`을 곱해서 스케일이 작을수록 약한 힘이 적용되도록 변경했습니다.

```swift
// Before
let multiplier: CGFloat = 0.3
```

```swift
// After
let bundleScale = KeyringScale.bundleKeyringScale(for: carabinerId)
let multiplier: CGFloat = 0.3 * bundleScale
```

> 간단하게, 0.3에 스케일을 곱하는 식으로 해봤는데 매우 적절한 해결법이었음.


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->



https://github.com/user-attachments/assets/fc0df399-311f-46ee-a22f-c20a8443aabc




## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #158 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
