### PR TITLE
fix: [뭉치] - 뭉치 생성에서 카라비너 변경 시 앱 종료 현상 픽스

### DIFF
--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Capture.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Capture.swift
@@ -12,8 +12,10 @@ extension BundleCreateView {
     /// 키링 데이터 리스트 생성 (씬 표시용)
     func createKeyringDataList(carabiner: Carabiner) -> [MultiKeyringScene.KeyringData] {
         var dataList: [MultiKeyringScene.KeyringData] = []
+        let maxCount = carabiner.keyringXPosition.count
 
         for index in keyringOrder {
+            guard index < maxCount else { continue }  // 범위 초과된 index 스킵
             guard let keyring = selectedKeyrings[index] else { continue }
             let soundId = keyring.soundId
 

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
@@ -111,6 +111,15 @@ extension BundleCreateView {
                     viewModel: bundleVM,
                     selectedCarabiner: bundleVM.newSelectedCarabiner,
                     onCarabinerTap: { carabiner in
+                        let maxCount = carabiner.carabiner.maxKeyringCount  // 새 카라비너 슬롯 수
+                        
+                        // 슬롯 초과 키링 제거
+                        let overflowIndices = selectedKeyrings.keys.filter { $0 >= maxCount }
+                        for idx in overflowIndices {
+                            selectedKeyrings[idx] = nil
+                            keyringOrder.removeAll { $0 == idx }
+                        }
+                        
                         // 정적 카라비너 + 캐시 미스일 때만 로딩 표시
                         if !carabiner.carabiner.isLottie && !isCarabinerCached(carabiner) {
                             isSceneReady = false


### PR DESCRIPTION
## 🎯 PR 내용
### 문제 상황
카라비너에 키링을 장착한 상태에서 장착된 키링 개수보다 적은 슬롯의 카라비너를 선택하면 앱이 종료되는 문제가 발생함

### 원인
createKeyringDataList에서 keyringOrder의 index로 carabiner.keyringXPosition[index]에 접근할 때, 새 카라비너의 배열 범위를 초과하여 `Thread 1: Fatal error: Index out of range` 오류로 크래시 발생.

### 해결 방안
- `BundleCreateView+Capture.swift`

   - createKeyringDataList에서 현재 카라비너의 최대 슬롯 수(keyringXPosition.count)를 기준으로 범위 초과 index를 guard로 스킵

- `BundleCreateView+SelectSheet.swift`

   - `onCarabinerTap` 클로저에서 새 카라비너로 변경하기 전, maxKeyringCount를 초과하는 index의 키링을 selectedKeyrings와 keyringOrder에서 사전 제거


## 🔗 관련 이슈
#162 

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
