### PR TITLE
fix: [뭉치] - 뭉치 이름 입력에서 뒤로가면 카라비너와 배경이 초기화 되는 버그 픽스

### DIFF
--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Capture.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Capture.swift
@@ -12,8 +12,10 @@ extension BundleCreateView {
     /// 키링 데이터 리스트 생성 (씬 표시용)
     func createKeyringDataList(carabiner: Carabiner) -> [MultiKeyringScene.KeyringData] {
         var dataList: [MultiKeyringScene.KeyringData] = []
+        let maxCount = carabiner.keyringXPosition.count
 
         for index in keyringOrder {
+            guard index < maxCount else { continue }  // 범위 초과된 index 스킵
             guard let keyring = selectedKeyrings[index] else { continue }
             let soundId = keyring.soundId
 

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Capture.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+Capture.swift
@@ -143,6 +143,7 @@ extension BundleCreateView {
         // 캡처 완료 후 다음 화면으로 이동
         await MainActor.run {
             isCapturing = false
+            isNavigatingDeeper = true
             router.push(.bundleNameInputView)
         }
     }

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView+SelectSheet.swift
@@ -111,6 +111,15 @@ extension BundleCreateView {
                     viewModel: bundleVM,
                     selectedCarabiner: bundleVM.newSelectedCarabiner,
                     onCarabinerTap: { carabiner in
+                        let maxCount = carabiner.carabiner.maxKeyringCount  // 새 카라비너 슬롯 수
+                        
+                        // 슬롯 초과 키링 제거
+                        let overflowIndices = selectedKeyrings.keys.filter { $0 >= maxCount }
+                        for idx in overflowIndices {
+                            selectedKeyrings[idx] = nil
+                            keyringOrder.removeAll { $0 == idx }
+                        }
+                        
                         // 정적 카라비너 + 캐시 미스일 때만 로딩 표시
                         if !carabiner.carabiner.isLottie && !isCarabinerCached(carabiner) {
                             isSceneReady = false

--- a/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Create/BundleCreateView.swift
@@ -42,6 +42,7 @@ struct BundleCreateView<Route: BundleRoute>: View {
     @State var isCapturing: Bool = false
     @State var sceneRefreshId = UUID()
     @State var isSceneReady: Bool = false
+    @State var isNavigatingDeeper = true // router push를 하는지 여부
 
     // 구매 시트
     @State var showPurchaseSheet = false
@@ -158,7 +159,10 @@ struct BundleCreateView<Route: BundleRoute>: View {
             bundleVM.resetSheetFilterState()
         }
         .onDisappear {
-            bundleVM.resetEditState()
+            if !isNavigatingDeeper {
+                bundleVM.resetEditState()
+            }
+            isNavigatingDeeper = false
         }
         .sheet(isPresented: $showPurchaseSheet) {
             purchaseSheetView


### PR DESCRIPTION
## 🎯 PR 내용
### 문제 상황
뭉치 생성 화면에서 카라비너와 배경을 선택하고 이름 입력 화면까지 진행한 뒤 뒤로가기 시, 이전에 선택했던 카라비너와 배경이 초기화되어 기본값으로 돌아오는 문제가 발생함

### 원인
onDisappear할 때 resetEditState 함수가 호출되어 편집 데이터가 모두 초기화되는데, 이때 onDisappear되는 케이스가 이름 설정 화면으로 갈 때와 뭉치 생성 화면 이전(완전 밖)으로 갈 때 두 가지 케이스가 구분되지 않고 두 케이스 모두 초기화 함수가 호출됨
```swift
        .onDisappear {
            bundleVM.resetEditState()
        }
```

### 해결방안
- `BundleCreateView.swift`
   - router push를 하는지 여부를 나타내는 `isNavigatingDeeper` 프로퍼티 추가
   - onDisappear에서 isNavigatingDeeper가 false일 때만 resetEditState() 호출하도록 수정

- `BundleCreateView+Capture.swift`
   - captureAndSaveScene에서 router push 직전에 isNavigatingDeeper = true 설정


## 🔗 관련 이슈
#164 

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
