### PR TITLE
style: 프리뷰에서 작게 보였던 정적 카라비너 표현식 수정

### DIFF
--- a/Keychy/Keychy/Presentation/Workshop/Views/Main/WorkshopItemDetailView.swift
+++ b/Keychy/Keychy/Presentation/Workshop/Views/Main/WorkshopItemDetailView.swift
@@ -211,7 +211,8 @@ extension WorkshopItemDetailView {
                 } else {
                     // 카라비너, 사운드: 1:1 비율
                     ItemDetailImage(itemURL: getPreviewURL())
-                        .aspectRatio(1, contentMode: .fit)
+                        .scaledToFit()
+                        .padding(.vertical, 60)
                         .frame(maxWidth: .infinity)
                 }
             }


### PR DESCRIPTION
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

**아이템 프리뷰**는 **로티카라비너/정적카라비너/로티배경/정적배경** 등등 
이런 **타입에 따라 다른 크기**로 이미지를 보여준다. 

그런데 정적 카라비너의 경우 1:1 크기 고정 처리가 있었고,
그에 따라 매우 작은 크기로 나왔음.

- aspectRatio로 항상 1:1로 나왔었음.
- 비율식을 제거하고 vertical 패딩 추가


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

<img width="250" alt="뭉치 정적 카라비너 아이템 프리뷰 비율 " src="https://github.com/user-attachments/assets/e8532b5e-b5a8-4867-9a59-691e04bb6632" />

> 잘나옴

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #171 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
