### PR TITLE
feat: 키치 스튜디오의 푸시 알림 수신 구현 (키링 배포 기능 까지 추가)

### DIFF
--- a/Keychy/Keychy/App/AppDelegate.swift
+++ b/Keychy/Keychy/App/AppDelegate.swift
@@ -128,8 +128,20 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) {
         let userInfo = response.notification.request.content.userInfo
 
-        // postOfficeId 추출해서 화면 이동
-        if let postOfficeId = userInfo["postOfficeId"] as? String {
+        // 키치 소식 푸시 (공지 / 키링 배포)
+        if let type = userInfo["type"] as? String {
+            switch type {
+            case "announcement":
+                let destination = userInfo["deepLink"] as? String ?? "홈"
+                DeepLinkManager.shared.handleNewsPush(destination: destination)
+            case "keyringEvent":
+                DeepLinkManager.shared.handleNewsPush(destination: "보관함")
+            default:
+                break
+            }
+        }
+        // 기존 선물 알림 (postOfficeId 기반)
+        else if let postOfficeId = userInfo["postOfficeId"] as? String {
             DeepLinkManager.shared.handleDeepLink(postOfficeId: postOfficeId, type: .notification)
         }
 

--- a/Keychy/Keychy/App/AppDelegate.swift
+++ b/Keychy/Keychy/App/AppDelegate.swift
@@ -135,7 +135,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 let destination = userInfo["deepLink"] as? String ?? "홈"
                 DeepLinkManager.shared.handleNewsPush(destination: destination)
             case "keyringEvent":
-                DeepLinkManager.shared.handleNewsPush(destination: "보관함")
+                if let postOfficeId = userInfo["postOfficeId"] as? String, !postOfficeId.isEmpty {
+                    // postOfficeId가 있으면 기존 collect 수령 플로우로 연결
+                    DeepLinkManager.shared.handleDeepLink(postOfficeId: postOfficeId, type: .collect)
+                } else {
+                    DeepLinkManager.shared.handleNewsPush(destination: "보관함")
+                }
             default:
                 break
             }

--- a/Keychy/Keychy/Core/DeepLink/DeepLinkManager.swift
+++ b/Keychy/Keychy/Core/DeepLink/DeepLinkManager.swift
@@ -28,6 +28,9 @@ class DeepLinkManager {
     var pendingPostOfficeId: String?
     var pendingDeepLinkType: DeepLinkType?
     var pendingError: DeepLinkError?
+
+    // 키치 소식 푸시 알림 → 탭 이동용
+    var pendingTabDestination: String?
     
     private init() {}
     
@@ -83,6 +86,20 @@ class DeepLinkManager {
         }
     }
     
+    // 키치 소식 푸시 → 탭 이동 처리
+    func handleNewsPush(destination: String) {
+        DispatchQueue.main.async {
+            self.pendingTabDestination = destination
+        }
+    }
+
+    // 탭 이동 대기열 소비 (한 번만 사용)
+    func consumePendingTab() -> String? {
+        guard let destination = pendingTabDestination else { return nil }
+        pendingTabDestination = nil
+        return destination
+    }
+
     func consumePendingDeepLink() -> (postOfficeId: String, type: DeepLinkType, error: DeepLinkError?)? {
         guard let postOfficeId = pendingPostOfficeId,
               let type = pendingDeepLinkType else {

--- a/Keychy/Keychy/Core/DeepLink/DeepLinkManager.swift
+++ b/Keychy/Keychy/Core/DeepLink/DeepLinkManager.swift
@@ -19,6 +19,7 @@ enum DeepLinkError {
     case notFound           // 존재하지 않는 링크
     case missingType        // type 필드 없음
     case typeMismatch       // URL 타입과 문서 타입 불일치
+    case expired            // 배포 만료
 }
 
 @Observable
@@ -66,7 +67,7 @@ class DeepLinkManager {
             
             // 3. URL 타입과 문서 타입 비교
             let isValid = self.validateLinkType(urlType: type, documentType: documentType)
-            
+
             guard isValid else {
                 print("타입 불일치 - URL: \(type), Document: \(documentType)")
                 DispatchQueue.main.async {
@@ -76,8 +77,22 @@ class DeepLinkManager {
                 }
                 return
             }
-            
-            // 4. 검증 통과 → 정상 처리
+
+            // 4. 만료 검증 — expiresAt이 nil이면 무한배포(통과), 있으면 현재 시간과 비교
+            if let expiresTimestamp = data["expiresAt"] as? Timestamp {
+                let expiresDate = expiresTimestamp.dateValue()
+                if expiresDate < Date() {
+                    print("배포 만료 - 만료일: \(expiresDate)")
+                    DispatchQueue.main.async {
+                        self.pendingPostOfficeId = postOfficeId
+                        self.pendingDeepLinkType = type
+                        self.pendingError = .expired
+                    }
+                    return
+                }
+            }
+
+            // 5. 검증 통과 → 정상 처리
             DispatchQueue.main.async {
                 self.pendingPostOfficeId = postOfficeId
                 self.pendingDeepLinkType = type

--- a/Keychy/Keychy/Core/Firebase/UserManager.swift
+++ b/Keychy/Keychy/Core/Firebase/UserManager.swift
@@ -96,6 +96,9 @@ class UserManager {
                 // 실시간 리스너 시작
                 self.startUserListener(uid: uid)
 
+                // keychyNews 토픽 구독 동기화 (앱 재설치/재로그인 대응)
+                NotificationManager.shared.syncKeychyNewsSubscription(marketingAgreed: user.marketingAgreed)
+
                 completion(true)
             } else {
                 // 신규 유저 또는 프로필 미완성

--- a/Keychy/Keychy/Core/Notification/NotificationManager.swift
+++ b/Keychy/Keychy/Core/Notification/NotificationManager.swift
@@ -93,6 +93,39 @@ class NotificationManager: NSObject {
         }
     }
 
+    // MARK: - FCM 토픽 구독 관리
+
+    /// keychyNews 토픽 구독 (마케팅 알림 수신 동의 시)
+    func subscribeToKeychyNews() {
+        Messaging.messaging().subscribe(toTopic: "keychyNews") { error in
+            if let error = error {
+                print("[FCM] keychyNews 토픽 구독 실패: \(error.localizedDescription)")
+            } else {
+                print("[FCM] keychyNews 토픽 구독 성공")
+            }
+        }
+    }
+
+    /// keychyNews 토픽 구독 해제 (마케팅 알림 수신 거부 시)
+    func unsubscribeFromKeychyNews() {
+        Messaging.messaging().unsubscribe(fromTopic: "keychyNews") { error in
+            if let error = error {
+                print("[FCM] keychyNews 토픽 구독 해제 실패: \(error.localizedDescription)")
+            } else {
+                print("[FCM] keychyNews 토픽 구독 해제 성공")
+            }
+        }
+    }
+
+    /// marketingAgreed 값에 따라 토픽 구독 상태 동기화
+    func syncKeychyNewsSubscription(marketingAgreed: Bool) {
+        if marketingAgreed {
+            subscribeToKeychyNews()
+        } else {
+            unsubscribeFromKeychyNews()
+        }
+    }
+
     // MARK: - FCM 토큰 갱신 처리
     /// 토큰이 갱신될 때마다 호출 (MessagingDelegate에서 사용)
     func updateFCMToken(_ token: String, userId: String) {

--- a/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel+Distribution.swift
+++ b/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel+Distribution.swift
@@ -35,6 +35,8 @@ extension CollectionViewModel {
                     )
                     
                     // 3. 새 키링 생성 (복사본)
+                    // collect 배포는 senderId를 "KEYCHY"로 저장
+                    // → 디테일뷰에서 선물 보낸 사람이 "KEYCHY"로 표시됨
                     let copiedKeyring = Keyring(
                         name: originalKeyring.name,
                         bodyImage: newBodyImageURL,
@@ -51,7 +53,7 @@ extension CollectionViewModel {
                         chainLength: originalKeyring.chainLength,
                         isEditable: false,
                         isNew: true,
-                        senderId: senderId,
+                        senderId: "KEYCHY",
                         receivedAt: Date(),
                         hookOffsetY: originalKeyring.hookOffsetY
                     )

--- a/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel+Distribution.swift
+++ b/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel+Distribution.swift
@@ -15,6 +15,7 @@ extension CollectionViewModel {
         keyringId: String,
         senderId: String,
         receiverId: String,
+        senderDisplayName: String = "KEYCHY",
         completion: @escaping (Bool, String?) -> Void
     ) {
         // 1. 기존 fetchKeyringById로 키링 데이터 가져오기
@@ -35,8 +36,8 @@ extension CollectionViewModel {
                     )
                     
                     // 3. 새 키링 생성 (복사본)
-                    // collect 배포는 senderId를 "KEYCHY"로 저장
-                    // → 디테일뷰에서 선물 보낸 사람이 "KEYCHY"로 표시됨
+                    // senderId에 Studio에서 설정한 표시명 저장
+                    // → 디테일뷰에서 선물 보낸 사람으로 표시됨
                     let copiedKeyring = Keyring(
                         name: originalKeyring.name,
                         bodyImage: newBodyImageURL,
@@ -53,7 +54,7 @@ extension CollectionViewModel {
                         chainLength: originalKeyring.chainLength,
                         isEditable: false,
                         isNew: true,
-                        senderId: "KEYCHY",
+                        senderId: senderDisplayName,
                         receivedAt: Date(),
                         hookOffsetY: originalKeyring.hookOffsetY
                     )

--- a/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel+Package.swift
+++ b/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel+Package.swift
@@ -71,18 +71,9 @@ extension CollectionViewModel {
                 }
                 
                 print("PostOffice 데이터 조회 성공")
-                
-                var postOfficeData: [String: Any] = [
-                    "senderId": senderId,
-                    "keyringId": keyringId
-                ]
-                
-                // receiverId 필드가 있으면 포함
-                if let receiverId = data["receiverId"] as? String {
-                    postOfficeData["receiverId"] = receiverId
-                }
-                
-                completion(postOfficeData)
+
+                // 전체 data를 그대로 전달 (senderDisplayName, expiresAt 등 포함)
+                completion(data)
             }
     }
 

--- a/Keychy/Keychy/Presentation/Collection/ViewModels/KeyringCollectViewModel.swift
+++ b/Keychy/Keychy/Presentation/Collection/ViewModels/KeyringCollectViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import FirebaseFirestore
 
 @Observable
 class KeyringCollectViewModel {
@@ -54,10 +55,20 @@ class KeyringCollectViewModel {
                 self.isLoading = false
                 return
             }
-            
+
+            // 만료 이중 검증 — DeepLinkManager에서 1차 검증 후 여기서 2차 확인
+            if let expiresTimestamp = postOfficeData["expiresAt"] as? Timestamp {
+                if expiresTimestamp.dateValue() < Date() {
+                    print("배포 만료 (2차 검증)")
+                    self.hasDeepLinkError = true
+                    self.isLoading = false
+                    return
+                }
+            }
+
             self.senderId = senderId
             self.keyringId = keyringId
-            
+
             // 키링 정보 가져오기
             self.loadKeyringInfo(keyringId: keyringId, senderId: senderId)
         }
@@ -79,11 +90,9 @@ class KeyringCollectViewModel {
                 self.authorName = name
             }
             
-            // senderId로 발신자 이름 로드
-            self.collectionViewModel.fetchUserName(userId: senderId) { name in
-                self.senderName = name
-                self.isLoading = false
-            }
+            // collect 타입은 Studio 배포이므로 발신자를 "KEYCHY"로 고정
+            self.senderName = "KEYCHY"
+            self.isLoading = false
         }
     }
     

--- a/Keychy/Keychy/Presentation/Collection/ViewModels/KeyringCollectViewModel.swift
+++ b/Keychy/Keychy/Presentation/Collection/ViewModels/KeyringCollectViewModel.swift
@@ -14,6 +14,7 @@ class KeyringCollectViewModel {
     var keyring: Keyring?
     var keyringId: String?
     var senderId: String?
+    var senderDisplayName: String?
     var senderName: String = ""
     var authorName: String = ""
     var isLoading: Bool = true
@@ -68,6 +69,7 @@ class KeyringCollectViewModel {
 
             self.senderId = senderId
             self.keyringId = keyringId
+            self.senderDisplayName = postOfficeData["senderDisplayName"] as? String
 
             // 키링 정보 가져오기
             self.loadKeyringInfo(keyringId: keyringId, senderId: senderId)
@@ -90,8 +92,8 @@ class KeyringCollectViewModel {
                 self.authorName = name
             }
             
-            // collect 타입은 Studio 배포이므로 발신자를 "KEYCHY"로 고정
-            self.senderName = "KEYCHY"
+            // Studio에서 설정한 표시명 사용, 없으면 "KEYCHY" fallback
+            self.senderName = self.senderDisplayName ?? "KEYCHY"
             self.isLoading = false
         }
     }
@@ -122,7 +124,8 @@ class KeyringCollectViewModel {
             self.collectionViewModel.collectKeyring(
                 keyringId: keyringId,
                 senderId: senderId,
-                receiverId: receiverId
+                receiverId: receiverId,
+                senderDisplayName: self.senderDisplayName ?? "KEYCHY"
             ) { success, errorMessage in
                 DispatchQueue.main.async {
                     self.isAccepting = false

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Lifecycle.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Lifecycle.swift
@@ -90,9 +90,15 @@ extension CollectionKeyringDetailView {
             self.senderName = "알 수 없음"
             return
         }
-        
+
+        // collect 배포 키링은 senderId가 "KEYCHY"로 저장됨
+        guard senderId != "KEYCHY" else {
+            self.senderName = "KEYCHY"
+            return
+        }
+
         let db = Firestore.firestore()
-        
+
         db.collection("User")
             .document(senderId)
             .getDocument { snapshot, error in
@@ -100,13 +106,13 @@ extension CollectionKeyringDetailView {
                     self.senderName = "알 수 없음"
                     return
                 }
-                
+
                 guard let data = snapshot?.data(),
                       let name = data["nickname"] as? String else {
                     self.senderName = "알 수 없음"
                     return
                 }
-                
+
                 self.senderName = name
             }
     }

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Lifecycle.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Lifecycle.swift
@@ -91,29 +91,19 @@ extension CollectionKeyringDetailView {
             return
         }
 
-        // collect 배포 키링은 senderId가 "KEYCHY"로 저장됨
-        guard senderId != "KEYCHY" else {
-            self.senderName = "KEYCHY"
-            return
-        }
-
         let db = Firestore.firestore()
 
         db.collection("User")
             .document(senderId)
             .getDocument { snapshot, error in
-                if error != nil {
-                    self.senderName = "알 수 없음"
-                    return
+                if let data = snapshot?.data(),
+                   let name = data["nickname"] as? String {
+                    // 실제 User 문서가 있으면 닉네임 사용 (1:1 선물)
+                    self.senderName = name
+                } else {
+                    // User 문서가 없으면 senderId 자체가 표시명 (collect 배포)
+                    self.senderName = senderId
                 }
-
-                guard let data = snapshot?.data(),
-                      let name = data["nickname"] as? String else {
-                    self.senderName = "알 수 없음"
-                    return
-                }
-
-                self.senderName = name
             }
     }
 }

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Lifecycle.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Lifecycle.swift
@@ -98,11 +98,13 @@ extension CollectionKeyringDetailView {
             .getDocument { snapshot, error in
                 if let data = snapshot?.data(),
                    let name = data["nickname"] as? String {
-                    // 실제 User 문서가 있으면 닉네임 사용 (1:1 선물)
                     self.senderName = name
                 } else {
-                    // User 문서가 없으면 senderId 자체가 표시명 (collect 배포)
-                    self.senderName = senderId
+                    // Firebase UID: ASCII 영숫자 28자
+                    let isFirebaseUID = senderId.count >= 28
+                        && senderId.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+
+                    self.senderName = isFirebaseUID ? "탈퇴한 회원" : senderId
                 }
             }
     }

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Sheet.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Sheet.swift
@@ -157,10 +157,13 @@ extension CollectionKeyringDetailView {
             Text(formattedDate(date: keyring.createdAt))
                 .typography(.suit14M)
             
-            Text("@\(authorName)")
-                .typography(.notosans14R)
-                .foregroundColor(.gray500)
-                .padding(.top, 10)
+            // collect 배포 키링이면 만든사람 숨김
+            if keyring.senderId != "KEYCHY" {
+                Text("@\(authorName)")
+                    .typography(.notosans14R)
+                    .foregroundColor(.gray500)
+                    .padding(.top, 10)
+            }
         }
     }
     

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Sheet.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Sheet.swift
@@ -157,13 +157,10 @@ extension CollectionKeyringDetailView {
             Text(formattedDate(date: keyring.createdAt))
                 .typography(.suit14M)
             
-            // collect 배포 키링이면 만든사람 숨김
-            if keyring.senderId != "KEYCHY" {
-                Text("@\(authorName)")
-                    .typography(.notosans14R)
-                    .foregroundColor(.gray500)
-                    .padding(.top, 10)
-            }
+            Text("@\(authorName)")
+                .typography(.notosans14R)
+                .foregroundColor(.gray500)
+                .padding(.top, 10)
         }
     }
     

--- a/Keychy/Keychy/Presentation/Home/ViewModels/MyPageViewModel.swift
+++ b/Keychy/Keychy/Presentation/Home/ViewModels/MyPageViewModel.swift
@@ -204,6 +204,8 @@ class MyPageViewModel {
                     }
                 } else {
                     print("마케팅 알림 설정 저장 성공: \(newValue)")
+                    // Firestore 저장 성공 → 토픽 구독/해제
+                    self?.notificationManager.syncKeychyNewsSubscription(marketingAgreed: newValue)
                     DispatchQueue.main.async {
                         if var user = userManager.currentUser {
                             user.marketingAgreed = newValue
@@ -226,13 +228,16 @@ class MyPageViewModel {
         }
 
         do {
-            // 1. Firebase Auth 로그아웃
+            // 1. keychyNews 토픽 구독 해제
+            notificationManager.unsubscribeFromKeychyNews()
+
+            // 2. Firebase Auth 로그아웃
             try Auth.auth().signOut()
 
-            // 2. UserManager 초기화
+            // 3. UserManager 초기화
             userManager.clearUserInfo()
 
-            // 3. 로그인 상태 변경 → RootView가 자동으로 IntroView로 전환
+            // 4. 로그인 상태 변경 → RootView가 자동으로 IntroView로 전환
             introViewModel.isLoggedIn = false
             introViewModel.needsProfileSetup = false
         } catch {

--- a/Keychy/Keychy/Presentation/Intro/ViewModels/IntroViewModel+Signup.swift
+++ b/Keychy/Keychy/Presentation/Intro/ViewModels/IntroViewModel+Signup.swift
@@ -58,7 +58,12 @@ extension IntroViewModel {
         newUser.termsAgreed = true
         newUser.marketingAgreed = tempMarketingAgreed
 
+        let marketingAgreed = tempMarketingAgreed
         UserManager.shared.saveProfile(user: newUser) { success in
+            if success {
+                // 마케팅 동의 시 keychyNews 토픽 구독
+                NotificationManager.shared.syncKeychyNewsSubscription(marketingAgreed: marketingAgreed)
+            }
             completion(success)
         }
     }

--- a/Keychy/Keychy/Presentation/Intro/ViewModels/IntroViewModel.swift
+++ b/Keychy/Keychy/Presentation/Intro/ViewModels/IntroViewModel.swift
@@ -112,6 +112,8 @@ class IntroViewModel: NSObject, ASAuthorizationControllerDelegate {
                     print("약관 동의 저장 실패: \(error.localizedDescription)")
                 } else {
                     print("약관 동의 저장 성공 - 마케팅: \(marketingAgreed)")
+                    // 마케팅 동의 시 keychyNews 토픽 구독
+                    NotificationManager.shared.syncKeychyNewsSubscription(marketingAgreed: marketingAgreed)
                 }
             }
     }

--- a/Keychy/Keychy/Presentation/Tab/ViewModels/MainTabViewModel.swift
+++ b/Keychy/Keychy/Presentation/Tab/ViewModels/MainTabViewModel.swift
@@ -64,6 +64,7 @@ class MainTabViewModel {
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(Delay.deepLinkCheck))
             checkPendingDeepLink()
+            checkPendingTabDestination()
         }
     }
 
@@ -77,7 +78,36 @@ class MainTabViewModel {
         }
     }
 
+    /// 키치 소식 푸시의 탭 이동 감지 시 호출
+    func handleTabDestinationChange(_: String?, newValue: String?) {
+        if newValue != nil {
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(Delay.deepLinkChange))
+                checkPendingTabDestination()
+            }
+        }
+    }
+
     // MARK: - Private Methods
+    /// 대기 중인 탭 이동이 있는지 확인하고 처리
+    private func checkPendingTabDestination() {
+        guard let destination = deepLinkManager.consumePendingTab() else { return }
+        switch destination {
+        case "홈":
+            selectedTab = TabIndex.home.rawValue
+        case "공방":
+            selectedTab = TabIndex.workshop.rawValue
+        case "보관함":
+            selectedTab = TabIndex.collection.rawValue
+        case "앱스토어":
+            if let url = URL(string: "itms-apps://itunes.apple.com/app/id6754951347") {
+                UIApplication.shared.open(url)
+            }
+        default:
+            selectedTab = TabIndex.home.rawValue
+        }
+    }
+
     /// 대기 중인 딥링크가 있는지 확인하고 처리
     private func checkPendingDeepLink() {
         if let (postOfficeId, type, error) = deepLinkManager.consumePendingDeepLink() {

--- a/Keychy/Keychy/Presentation/Tab/Views/MainTabView.swift
+++ b/Keychy/Keychy/Presentation/Tab/Views/MainTabView.swift
@@ -54,6 +54,7 @@ extension MainTabView {
         .tint(.main500)
         .onAppear(perform: viewModel.handleAppear)
         .onChange(of: viewModel.deepLinkManager.pendingPostOfficeId, viewModel.handleDeepLinkChange)
+        .onChange(of: viewModel.deepLinkManager.pendingTabDestination, viewModel.handleTabDestinationChange)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             // 앱이 포그라운드로 복귀할 때 배지 카운트 동기화
             viewModel.userManager.updateBadgeCount()


### PR DESCRIPTION
## 🎯 PR 내용 (v2 키링배포 까지 추가되었습니다.)
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

**Keychy Studio**(관리자 앱)에서 공지사항/키링 배포를 발송하면, 
사용자 앱에서 푸시 알림을 수신하고 탭 시 해당 화면으로 이동하기 위해 진행한 작업입니다.

Keychy Studio에서 Firestore에 문서를 생성하면, 
**Cloud Function**이 트리거되어 `keychyNews` FCM 토픽으로 푸시를 발송합니다.

이를 수신하려면 **사용자 앱에서 토픽 구독과 딥링크 처리가 필요**합니다.

```
Studio 공지 발송 
→ Firestore 문서 생성 
→ Cloud Function이 트리거 됨. 문서가 생기면서.
→ 펑션이 FCM 토픽을 푸시
                  ↓
    keychyNews 토픽 구독하신 분들에게 공지 전달
                  ↓
```

### 1. FCM 토픽 구독 (`keychyNews`)
- `marketingAgreed`(**키치 소식 알림**) 값에 따라 토픽 구독/해제
- 구독 시점: 회원가입 동의, 마이페이지 토글 ON, 앱 재설치 후 로그인
- 해제 시점: 마이페이지 토글 OFF, 로그아웃

### 2. 푸시 알림 딥링크 처리
  | 푸시 타입 | 탭 시 동작 |
  |----------|-----------|
  | 공지 (announcement) | `deepLink` 값에 따라 홈/공방/앱스토어 이동 |
  | [예정] 키링 배포 (keyringEvent) | 보관함 탭 이동 |
  | 선물 알림 (기존) | 기존 postOfficeId 로직 유지 |

### 3. 키링 배포 기능 

> Keychy Studio도 병렬적으로 진행하여, 
Keychy Studio 내용도 섞여있습니다.

키링 배포 기능은 대체적으로 기존 로직을 사용할 수 있기에 
Kechy에서의 많은 수정보다는 Keychy Studio에서 사용성을 높이는 구현들을 많이 했습니다.
실제 Keychy Studio를 확인해보면, 사용법이 직관적으로 이해가 될 것입니다.

- 배포 시 무한배포/만료일 설정 기능 추가 (PostOffice에 expiresAt 저장)
- 키링 배포 관리 화면 신규 (활성 이벤트 목록/상세/종료)
- 발송 이력에서 키링 배포 상세정보 표시 (이미지, 키링명, 배포자, 공유링크)
- Cloud Functions에 postOfficeId FCM data 필드 추가


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

### 예시 - 1
<img width="800" alt="image" src="https://github.com/user-attachments/assets/c877610c-0a84-498b-8cc0-98712acfa244" />

자 이렇게 스튜디오에서 공지를 보내면?


https://github.com/user-attachments/assets/f6c67097-4732-4763-8921-2b7e8759f1e6

이렇게 푸시알림이 바로 오고요. 누르면 딥링크도 잘 처리됩니다. 

### 예시 - 2

<img width="800" alt="image" src="https://github.com/user-attachments/assets/1fb1c3dc-6ea7-4dd2-9a9f-0322146311a4" />

업데이트 알림도 이런식으로 보내고요.

https://github.com/user-attachments/assets/10b49cb4-3c8f-43be-aa97-f3197d44f0a3

잘 들어가지네요.


> 공지보내기, **Keychy Studio** 구현 끝!


### 키링 배포
<img width="800" alt="image" src="https://github.com/user-attachments/assets/ddf1cb39-651a-4d47-b47f-ff9d8e6b1e07" />

이런식으로 운영자 키링 보관함에서 키링을 고르고 보낼 수 있습니다.

무한 배포를 한 경우, 파이어베이스에서 문서를 지우면 만료가 되는데. 
스튜디오에서도 삭제할 수 있게 기능을 만들어두었습니다.

그리고 특정 기간 배포를 한 경우, 특정 기간이 되면 자동으로 문서가 삭제되고 만료됩니다.

모든 이력을 볼 수 있는 '발송 이력' 메뉴도 만들어두었습니다.

> 딥링크로 실어보내는 방식이고. 

보내는 순간 PostOffice문서와 KeyringEvents문서가 파이어베이스에 생깁니다. 


<img width="200" alt="키링배포" src="https://github.com/user-attachments/assets/1ad96dec-bb05-44f9-8d53-2ca12d49534f" />

> 운영자가 배포하면, 키링 제작자 표시가 없습니다. 선물 한 사람만 @Keychy로 보입니다.


<img width="700" alt="image" src="https://github.com/user-attachments/assets/374d55e8-76bd-4a66-9e00-d58fdb7050f1" />

> 기간이 만료되면 포스트오피스에서 삭제됩니다.

https://github.com/user-attachments/assets/770aa412-23da-4d34-91ab-845a47886e48


## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #175 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
