### PR TITLE
fix: [키링상세/선물뷰] - 포장된 키링의 제작자 닉네임 대신 sender 닉네임이 보여지는 현상 픽스

### DIFF
--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Lifecycle.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringDetailView+Lifecycle.swift
@@ -97,16 +97,16 @@ extension CollectionKeyringDetailView {
             .document(senderId)
             .getDocument { snapshot, error in
                 if error != nil {
-                    self.senderName = "알 수 없음"
+                    self.senderName = "탈퇴한 회원"
                     return
                 }
-                
+
                 guard let data = snapshot?.data(),
                       let name = data["nickname"] as? String else {
-                    self.senderName = "알 수 없음"
+                    self.senderName = "탈퇴한 회원"
                     return
                 }
-                
+
                 self.senderName = name
             }
     }

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringPackageView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringPackageView.swift
@@ -322,19 +322,26 @@ extension CollectionKeyringPackageView {
                     print("ShareLink 로드: \(link)")
                 }
                 
-                // 발신자 정보 로드
-                if let senderId = data["senderId"] as? String {
-                    db.collection("User")
-                        .document(senderId)
-                        .getDocument { userSnapshot, userError in
-                            if let userData = userSnapshot?.data(),
-                               let name = userData["nickname"] as? String {
-                                self.packageAuthorName = name
-                            } else {
-                                self.packageAuthorName = "알 수 없음"
-                            }
+                // 키링 제작자 정보 로드
+                db.collection("Keyring")
+                    .document(keyringDocId)
+                    .getDocument { keyringSnapshot, keyringError in
+                        if let keyringError {
+                            print("Keyring 조회 실패: \(keyringError.localizedDescription)")
+                            self.packageAuthorName = "알 수 없음"
+                            return
                         }
-                }
+                        
+                        guard let authorId = keyringSnapshot?.data()?["authorId"] as? String else {
+                            print("authorId 없음")
+                            self.packageAuthorName = "알 수 없음"
+                            return
+                        }
+                        
+                        self.viewModel.fetchUserNickname(userId: authorId) { nickname in
+                            self.packageAuthorName = nickname ?? "알 수 없음"
+                        }
+                    }
             }
     }
     

--- a/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringPackageView.swift
+++ b/Keychy/Keychy/Presentation/Collection/Views/Detail/CollectionKeyringPackageView.swift
@@ -328,18 +328,18 @@ extension CollectionKeyringPackageView {
                     .getDocument { keyringSnapshot, keyringError in
                         if let keyringError {
                             print("Keyring 조회 실패: \(keyringError.localizedDescription)")
-                            self.packageAuthorName = "알 수 없음"
+                            self.packageAuthorName = "탈퇴한 회원"
                             return
                         }
-                        
+
                         guard let authorId = keyringSnapshot?.data()?["authorId"] as? String else {
                             print("authorId 없음")
-                            self.packageAuthorName = "알 수 없음"
+                            self.packageAuthorName = "탈퇴한 회원"
                             return
                         }
                         
                         self.viewModel.fetchUserNickname(userId: authorId) { nickname in
-                            self.packageAuthorName = nickname ?? "알 수 없음"
+                            self.packageAuthorName = nickname ?? "탈퇴한 회원"
                         }
                     }
             }


### PR DESCRIPTION
## 🎯 PR 내용
### 문제 상황
그동안 포장된 키링 상세뷰로 이동하면 포장된 키링의 제작자 닉네임 대신 sender 닉네임이 보여지고 있었음. 그동안 발신자 정보를 로드하고 있었던 것.
> 왜 이제 발견했을까..?
> 좌측 이미지 -> 포장 완료 시, 키링의 제작자 닉네임이 제대로 뜸.
> 우측 이미지 -> 포장된 키링 상세뷰로 가면 보내는 사람 닉네임으로 뜸
<img width="201" height="437" alt="IMG_8851" src="https://github.com/user-attachments/assets/e4a2a713-23a4-4623-9077-56684498e685" />
<img width="201" height="437" alt="IMG_8852" src="https://github.com/user-attachments/assets/e1edce4d-1db1-4ffd-b7c9-eb8926cc5688" />

### 해결 방법
발신자 정보 로드 대신에 키링 제작자 정보를 로드하도록 함.

```
keyringId와 일치하는 Keyring 문서를 찾아서 authorId를 가져옴
-> 기존에 구현해두었던 `fetchUserNickname` 함수로 authorId에 해당하는 유저 닉네임 가져옴
```

> 길 PR 확인하면서 발견함... 이제라도 발견해서 다행.
> 아까 이야기했던 것 관련해서, "알 수 없음" 이나 "탈퇴한 회원" 둘 중 하나로 정하시고 "탈퇴한 회원"으로 바꾸신다면 지금 앱 전체적으로 "알 수 없음"으로 되어있는 부분 다 바꿔주시면 돼요!


## 📱 스크린샷 (UI 변경 시)
> 좌 : 수정 전
> 우 : 수정 후 (제작자 닉네임으로 잘 뜸!)

<img width="201" height="437" alt="IMG_8852" src="https://github.com/user-attachments/assets/e1edce4d-1db1-4ffd-b7c9-eb8926cc5688" />
<img width="201" height="437" alt="IMG_8854" src="https://github.com/user-attachments/assets/aeb49986-af0a-4069-86a1-c71bc751cccb" />



## 🔗 관련 이슈
#179 

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
