### PR TITLE
feat: [뭉치] - 템플릿별 뭉치용 스케일 처리 추가

### DIFF
--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScale.swift
@@ -65,6 +65,18 @@ enum KeyringScale {
         "Baekgu": 0.6,
         "Nureungi": 0.6,
     ]
+    
+    // MARK: - 템플릿별 뭉치 키링 스케일
+    private static let templateBodyScales: [String: CGFloat] = [
+        "Polaroid":     0.85,
+        "AcrylicPhoto": 1.0,
+        "ClearSketch":  1.0,
+        "PixelKeyring": 0.7,
+        "SpeechBubble": 1.0,
+        "WishHorse26":  1.0,
+        "DuZzonKu":     0.9,
+        "CrossStitch":  0.7
+    ]
 
     // MARK: - 위젯 출력 크기 (템플릿별)
     /// 위젯 프레임 합성 후 최종 축소 크기 (px)
@@ -101,6 +113,7 @@ enum KeyringScale {
     private static let defaultMaxSize = CGSize(width: 210, height: 210)
     private static let defaultZoomScale: CGFloat = 1.0
     private static let defaultCarabinerScale: CGFloat = 0.65
+    private static let defaultTemplateBodyScale: CGFloat = 1.0
     private static let defaultWidgetBodyOffsetY: CGFloat = 0
     private static let defaultWidgetOutputSize: Int = 500
     private static let defaultWidgetBodyClamp: CGFloat = 0.7
@@ -117,9 +130,14 @@ enum KeyringScale {
         return templateZoomScales[template]?[screen] ?? defaultZoomScale
     }
 
-    /// 카라비너별 뭉치 키링 스케일 반환
+    /// 카라비너별 뭉치 키링 스케일 반환 (링, 체인, 바디 공통)
     static func bundleKeyringScale(for carabiner: String) -> CGFloat {
         return carabinerScales[carabiner] ?? defaultCarabinerScale
+    }
+    
+    /// 템플릿별 뭉치 바디 추가 스케일 (바디에만 적용)
+    static func bundleBodyScale(for template: String?) -> CGFloat {
+        return templateBodyScales[template ?? ""] ?? defaultTemplateBodyScale
     }
 
     /// 위젯 합성 시 템플릿별 바디 Y 보정값 반환

--- a/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringCaptureScene.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringCaptureScene.swift
@@ -445,7 +445,8 @@ class MultiKeyringCaptureScene: SKScene {
 
             // 뭉치용 키링 스케일 적용
             let bundleScale = KeyringScale.bundleKeyringScale(for: self.carabinerId)
-            body.setScale(bundleScale)
+            let bodyScale = KeyringScale.bundleBodyScale(for: templateId)
+            body.setScale(bundleScale * bodyScale)
 
             let bodyFrame = body.calculateAccumulatedFrame()
             let bodyHalfHeight = bodyFrame.height / 2

--- a/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
@@ -825,10 +825,12 @@ class MultiKeyringScene: SKScene {
 
         // 뭉치용 키링 스케일 적용 (카라비너는 그대로, 키링 바디만 축소)
         let bundleScale = KeyringScale.bundleKeyringScale(for: carabinerId)
+        // 템플릿 추가 스케일 (바디에만 적용)
+        let bodyScale = KeyringScale.bundleBodyScale(for: templateId)
 
         let displaySize = CGSize(
-            width: originalSize.width * scale * bundleScale,
-            height: originalSize.height * scale * bundleScale
+            width: originalSize.width * scale * bundleScale * bodyScale,
+            height: originalSize.height * scale * bundleScale * bodyScale
         )
 
         let texture = SKTexture(image: image)


### PR DESCRIPTION
## 🎯 PR 내용

기존에는 뭉치에 건 키링 전체(링, 체인, 바디)에 카라비너별 스케일만 적용되고 있었음

폴라로이드, 픽셀, 십자수 템플릿의 경우 타 템플릿에 비해 바디 크기가 너무 커서 카라비너의 옆 구멍 영역을 침범하여 시각적으로 부자연스러운 모습이 있었음

따라서 템플릿별 스케일을 추가로 조정하는 기능 추가함

### 변경 사항
- 템플릿별 뭉치 바디 스케일 테이블 `templateBodyScales` 추가
```swift
    // MARK: - 템플릿별 뭉치 키링 스케일
    private static let templateBodyScales: [String: CGFloat] = [
        "Polaroid":     0.85,
        "AcrylicPhoto": 1.0,
        "ClearSketch":  1.0,
        "PixelKeyring": 0.7,
        "SpeechBubble": 1.0,
        "WishHorse26":  1.0,
        "DuZzonKu":     0.9,
        "CrossStitch":  0.7
    ]
```
- 기본값 `defaultTemplateBodyScale` 추가
- createBodyNode에서 bundleBodyScale을 추가로 곱해 displaySize 계산
- 캡처 씬의 바디 스케일 적용부에도 동일하게 bundleBodyScale 반영

## 📱 스크린샷 (UI 변경 시)

<img width="201" height="437" alt="IMG_9186" src="https://github.com/user-attachments/assets/eaa5701c-613c-4e94-a590-ffefab7d6e57" />
<img width="201" height="437" alt="IMG_9185" src="https://github.com/user-attachments/assets/9024baa5-58f1-4e3e-b941-fccd666a0110" />



## 🔗 관련 이슈
#182 

## ✅ 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
