### PR TITLE
fix: migrateUserFieldsIfNeeded가 전체 필드를 덮어쓰는 버그 수정

### DIFF
--- a/Keychy/Keychy/Core/Firebase/UserManager.swift
+++ b/Keychy/Keychy/Core/Firebase/UserManager.swift
@@ -148,6 +148,9 @@ class UserManager {
         UserDefaults.standard.set(user.email, forKey: "userEmail")
         UserDefaults.standard.set(user.marketingAgreed, forKey: "userMarketingAgreed")
         UserDefaults.standard.set(user.giftNotificationEnabled, forKey: "userGiftNotificationEnabled")
+        // 핵심 값 캐시 (stale 캐시로 인한 데이터 유실 방어)
+        UserDefaults.standard.set(user.maxKeyringCount, forKey: "userMaxKeyringCount")
+        UserDefaults.standard.set(user.coin, forKey: "userCoin")
     }
 
     private func loadFromCache() {
@@ -167,6 +170,12 @@ class UserManager {
             )
             user.marketingAgreed = marketingAgreed
             user.giftNotificationEnabled = giftNotificationEnabled
+            // 캐시된 핵심 값 복원 (stale 기본값으로 Firestore 덮어쓰기 방지)
+            user.maxKeyringCount = UserDefaults.standard.integer(forKey: "userMaxKeyringCount")
+            user.coin = UserDefaults.standard.integer(forKey: "userCoin")
+            // integer(forKey:)는 키가 없으면 0 반환 → 최초 설치 시 기본값 사용
+            if user.maxKeyringCount == 0 { user.maxKeyringCount = 100 }
+
             currentUser = user
             isLoaded = true
         }
@@ -174,10 +183,21 @@ class UserManager {
 
     // MARK: - 필드 마이그레이션
     private func migrateUserFieldsIfNeeded(user: KeychyUser) {
-        // merge: true로 누락된 필드만 추가 (기존 데이터는 유지)
-        let userData = user.toDictionary()
-        db.collection("User").document(user.id).setData(userData, merge: true) { error in
-            // 필드 마이그레이션 처리
+        // 신규 앱 버전에서 추가된 필드만 merge
+        // keyrings, coin, maxKeyringCount 등 동적 필드는 절대 포함하지 않음
+        // setData(merge: true)는 딕셔너리에 없는 필드는 건드리지 않으므로 안전
+        let migrationFields: [String: Any] = [
+            "recentTemplates": user.recentTemplates,
+            "giftNotificationEnabled": user.giftNotificationEnabled,
+            "copyVoucher": user.copyVoucher,
+            "termsAgreed": user.termsAgreed,
+            "marketingAgreed": user.marketingAgreed,
+        ]
+
+        db.collection("User").document(user.id).setData(migrationFields, merge: true) { error in
+            if let error = error {
+                print("[Migration] 필드 마이그레이션 실패: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -206,6 +226,8 @@ class UserManager {
         UserDefaults.standard.removeObject(forKey: "userUID")
         UserDefaults.standard.removeObject(forKey: "userMarketingAgreed")
         UserDefaults.standard.removeObject(forKey: "userGiftNotificationEnabled")
+        UserDefaults.standard.removeObject(forKey: "userMaxKeyringCount")
+        UserDefaults.standard.removeObject(forKey: "userCoin")
 
         // 키링 캐시 전체 삭제
         KeyringImageCache.shared.clearAll()


### PR DESCRIPTION
## Summary


<img width="550" height="367" alt="image" src="https://github.com/user-attachments/assets/8016e87c-cbb5-4bd0-bb4f-0d39967d9cef" />


### 설명 + 정리

- 여러 기기마다 최종적으로 저장된 데이터가 있음.
- 각 기기를 키면, 파이어베이스에서 데이터를 받아와서 연동을 함.
- 그런데 연동 중에, 인터넷이 불안정해짐
- 그 과정에서 파이어베이스 데이터가 아닌 로컬 데이터로 덮어씌워버림.
- 실제 이 동기화 코드에서 실패라는 것은. 최초의 유저임을 의미했기에.
- maxKeyringCount: 100, coin: 0임. 
- 그래서 그 값들만 변화한 것임.

> 헤븐은 기기를 총 3대를 사용하였다.
그런데, 실제 데이터가 특정일 기준으로 다 삭제된 것이 아닌. 
최근 키링 2개는 살아있었다.

그 말은, 이 버그는 항상 일어나는 버그가 아니라는 것임.

**특정 상황에서 벌어난 일.**

이 경우의 수는, 위에서 정리한 내용에 
네트워크가 불안정한 타이밍과 불필요한 코드가 데이터 로드에 있다.
라고 생각했음.


## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 버그 원인
`migrateUserFieldsIfNeeded`가 `loadUserInfo` 호출 시마다 
`user.toDictionary()`로 **User의 전체 필드를 Firestore에 덮어쓰고 있음**.

```swift
// 변경 전
private func migrateUserFieldsIfNeeded(user: KeychyUser) {
    let userData = user.toDictionary()  // keyrings, coin, maxKeyringCount 포함!
    db.collection("User").document(user.id).setData(userData, merge: true)
}
```

### 수정 내용

#### 1. migrateUserFieldsIfNeeded — 핵심 수정

마이그레이션 대상 필드(앱 업데이트로 새로 추가된 필드) 5개만 merge하도록 변경.
keyrings, coin, maxKeyringCount 등 동적 필드는 절대 포함하지 않음.


```swift
// 변경 후 (안전)
private func migrateUserFieldsIfNeeded(user: KeychyUser) {
    let migrationFields: [String: Any] = [
        "recentTemplates": user.recentTemplates,
        "giftNotificationEnabled": user.giftNotificationEnabled,
        "copyVoucher": user.copyVoucher,
        "termsAgreed": user.termsAgreed,
        "marketingAgreed": user.marketingAgreed,
    ]
    db.collection("User").document(user.id).setData(migrationFields, merge: true)
}
```


`setData(merge: true)`는 딕셔너리에 포함된 필드만 쓰고, 없는 필드는 건드리지 않으므로 기존 데이터 안전.

#### 2. saveToCache / loadFromCache — 방어 캐시 추가

maxKeyringCount, coin을 UserDefaults에도 캐시하여, 캐시에서 복원된 임시 User가 기본값(0)을 갖지 않도록 방어.

#### 3. clearUserInfo — 캐시 정리

로그아웃/회원탈퇴 시 추가된 캐시 키도 함께 삭제.


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #186 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료