### PR TITLE
fix: 뭉치 체인-바디 간격 보정

### DIFF
--- a/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
+++ b/Keychy/Keychy/Core/KeyringBundle/Scene/MultiKeyringScene.swift
@@ -821,7 +821,7 @@ class MultiKeyringScene: SKScene {
             let bodyHalfHeight = bodyFrame.height / 2
 
             let lastChainY = chainStartY - CGFloat(max(chains.count - 1, 0)) * chainSpacing
-            let lastChainBottomY = lastChainY - 15
+            let lastChainBottomY = lastChainY - 10.5
 
             var hookOffsetYRatio = data.hookOffsetY ?? 0.0
             if data.templateId == "PixelKeyring" || data.templateId == "Lenticular" { hookOffsetYRatio += 0.03 }


### PR DESCRIPTION
## Summary

**뭉치에서 체인 끝과 바디 구멍 사이 거리가 벌어져 있던 문제 수정**
  
## 🎯 PR 내용
### 원인
마지막 체인→바디 연결 오프셋(`-15px`)이 과도하게 바디를 아래로 밀어냄

### 수정
`MultiKeyringScene.swift`의 오프셋을 `-15` → `-10.5`로 조정하여 체인과 바디 구멍 위치 정렬

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

<img width="350" alt="스크린샷, 2026-04-03 14 20 28" src="https://github.com/user-attachments/assets/6a92cf51-50ab-4039-bc9a-28a5991cd5a0" />

> 다 잘됨

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #189 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
