### PR TITLE
fix: 렌티큘러 키링 복사/영상 생성 시 쉐이더 미적용 버그 수정

### DIFF
--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScene/KeyringScene.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScene/KeyringScene.swift
@@ -156,17 +156,22 @@ class KeyringScene: SKScene {
             }
             .store(in: &cancellables)
 
-        // 렌티큘러 VM인 경우 styleSubject 구독 → 시머/테두리 독립 실시간 업데이트
-        if let lenticularVM = viewModel as? LenticularVM {
-            // Setup 완료 후 초기 스타일 적용 (bodyNode 생성 이후)
-            let initialShimmer = lenticularVM.selectedShimmerColor
-            let initialBorder = lenticularVM.selectedBorderColor
+        // 렌티큘러 등 자이로 템플릿: 초기 스타일(시머/테두리) 적용
+        // - 편집 중(LenticularVM): selectedShimmerColor.firestoreId 반환
+        // - 영상 생성 시(KeyringAdapter): 저장된 Keyring 모델의 ID 반환
+        // 어느 경로든 `KeyringAppearanceColor.from(id:)`로 nil-safe 복원 가능
+        if viewModel.isGyroscope {
+            let initialShimmer = KeyringAppearanceColor.from(id: viewModel.shimmerColorId)
+            let initialBorder = KeyringAppearanceColor.from(id: viewModel.borderColorId)
             let originalSetupComplete = self.onSetupComplete
             self.onSetupComplete = { [weak self] in
                 self?.updateStyleUniforms(shimmer: initialShimmer, border: initialBorder)
                 originalSetupComplete?()
             }
+        }
 
+        // LenticularVM 전용: styleSubject 구독 → 편집 중 시머/테두리 실시간 업데이트
+        if let lenticularVM = viewModel as? LenticularVM {
             lenticularVM.styleSubject
                 .sink { [weak self] update in
                     self?.updateStyleUniforms(shimmer: update.shimmer, border: update.border)

--- a/Keychy/Keychy/Core/Video/Keyring/KeyringVideoGenerator+Keyring.swift
+++ b/Keychy/Keychy/Core/Video/Keyring/KeyringVideoGenerator+Keyring.swift
@@ -115,6 +115,16 @@ private class KeyringAdapter: KeyringViewModelProtocol {
         keyring.isGyroscope
     }
 
+    /// 렌티큘러 스타일 ID — 저장된 Keyring 모델의 값을 그대로 전달
+    /// KeyringScene이 `KeyringAppearanceColor.from(id:)`로 복원하여 셰이더에 적용
+    var shimmerColorId: String? {
+        keyring.shimmerColorId
+    }
+
+    var borderColorId: String? {
+        keyring.borderColorId
+    }
+
     var availableCustomizingModes: [CustomizingMode] {
         [.effect]
     }

--- a/Keychy/Keychy/Core/Video/Keyring/KeyringVideoGenerator+Setup.swift
+++ b/Keychy/Keychy/Core/Video/Keyring/KeyringVideoGenerator+Setup.swift
@@ -35,7 +35,6 @@ extension KeyringVideoGenerator {
         )
         scene.scaleMode = .aspectFill
         scene.size = CGSize(width: sceneWidth, height: sceneHeight)
-        scene.bind(to: viewModel)
 
         // 배경 이미지 추가 (scene보다 여유 있게 배치)
         if let bgImage = backgroundImage {
@@ -46,10 +45,14 @@ extension KeyringVideoGenerator {
             scene.addChild(backgroundNode)
         }
 
-        // Setup 완료 콜백 설정
+        // Setup 완료 콜백 설정 (bind 전에 설정해야 bind가 이 콜백을 래핑하여
+        // 렌티큘러 스타일 초기값을 적용할 수 있음)
         scene.onSetupComplete = {
             setupComplete()
         }
+
+        // VM 바인딩 (onSetupComplete 래핑 + 렌티큘러 스타일 초기 적용)
+        scene.bind(to: viewModel)
 
         return scene
     }

--- a/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel+Edit.swift
+++ b/Keychy/Keychy/Presentation/Collection/ViewModels/CollectionViewModel+Edit.swift
@@ -228,7 +228,10 @@ extension CollectionViewModel {
                     originalId: baseOriginalId,
                     chainLength: keyring.chainLength,
                     isNew: true,
-                    hookOffsetY: keyring.hookOffsetY
+                    hookOffsetY: keyring.hookOffsetY,
+                    isGyroscope: keyring.isGyroscope,
+                    shimmerColorId: keyring.shimmerColorId,
+                    borderColorId: keyring.borderColorId
                 )
 
                 // Firestore에 저장

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Protocols/KeyringViewModelProtocol.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Protocols/KeyringViewModelProtocol.swift
@@ -66,6 +66,13 @@ protocol KeyringViewModelProtocol: AnyObject, Observable {
     /// 자이로 인터랙션 사용 여부 (렌티큘러 등)
     var isGyroscope: Bool { get }
 
+    /// 시머(광택) 색상 ID (렌티큘러 등 스타일이 있는 템플릿용, 없으면 nil)
+    /// KeyringScene이 `KeyringAppearanceColor.from(id:)`로 변환하여 셰이더에 적용
+    var shimmerColorId: String? { get }
+
+    /// 테두리 색상 ID (렌티큘러 등 스타일이 있는 템플릿용, 없으면 nil)
+    var borderColorId: String? { get }
+
     /// 템플릿 ID
     var templateId: String { get }
 
@@ -167,6 +174,12 @@ extension KeyringViewModelProtocol {
 
     /// 기본값: 자이로 비사용
     var isGyroscope: Bool { false }
+
+    /// 기본값: 시머 색상 미지정 (렌티큘러가 아닌 템플릿은 nil 반환)
+    var shimmerColorId: String? { nil }
+
+    /// 기본값: 테두리 색상 미지정 (렌티큘러가 아닌 템플릿은 nil 반환)
+    var borderColorId: String? { nil }
 
     /// 기본 구현: 아무것도 하지 않음 (필요한 템플릿에서 override)
     func onModeChanged(from oldMode: CustomizingMode, to newMode: CustomizingMode) {}

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM.swift
@@ -80,6 +80,14 @@ class LenticularVM: KeyringViewModelProtocol {
     var chainLength: Int { template?.chainLength ?? 3 }
     var isGyroscope: Bool { template?.interactions.contains("tilt") ?? true }
 
+    // MARK: - KeyringViewModelProtocol: Style ID (렌티큘러 전용)
+    /// 시머 색상 ID — KeyringScene이 초기 스타일 적용 시 참조
+    /// 실시간 편집 업데이트는 `styleSubject`를 통해 별도로 처리됨
+    var shimmerColorId: String? { selectedShimmerColor.firestoreId }
+
+    /// 테두리 색상 ID — KeyringScene이 초기 스타일 적용 시 참조
+    var borderColorId: String? { selectedBorderColor.firestoreId }
+
     // MARK: - Customizing Modes
     /// 렌티큘러: 시머 색상 선택 + 이펙트
     var availableCustomizingModes: [CustomizingMode] { [.style, .effect] }


### PR DESCRIPTION
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

- 렌티큘러 키링 복사 시, A|B 형태의 아틀라스로 나오던 문제 해결 
- 영상 생성 시, 쉐이더 컬러/스타일 미적용 문제 해결

## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->
<img width="300" alt="스크린샷, 2026-04-08 14 15 24" src="https://github.com/user-attachments/assets/778e72d4-046f-4b40-84b1-d0101f3272a1" />

> **수정 후 / 수정 전**

https://github.com/user-attachments/assets/e879d325-90a8-4429-9714-302592dbba36

> 영상에서도 쉐이더 스타일 적용이 잘 됨. (수정 전에는 무조건 디폴트 고정이었음.)

## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #191 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
