### PR TITLE
fix: 이미지 확대하거나 이동해서 리사이징시 약간 반영이 이상하게 되는 이슈

### DIFF
--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM+ImageLoad.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM+ImageLoad.swift
@@ -67,7 +67,9 @@ extension LenticularVM {
     }
 
     /// 핀치 제스처 종료 시 스케일 적용 + 오프셋 재클램핑
+    /// - cardSize는 composeAtlas의 좌표계 변환을 위해 VM에도 저장됨
     func applyScale(_ gestureScale: CGFloat, target: ImageTarget, cardSize: CGSize) {
+        sourceCardSize = cardSize
         switch target {
         case .a:
             photoScaleA = min(max(photoScaleA * gestureScale, 1.0), 3.0)
@@ -81,7 +83,9 @@ extension LenticularVM {
     }
 
     /// 드래그 제스처 종료 시 오프셋 적용 (클램핑 포함)
+    /// - cardSize는 composeAtlas의 좌표계 변환을 위해 VM에도 저장됨
     func applyOffset(_ translation: CGSize, target: ImageTarget, cardSize: CGSize) {
+        sourceCardSize = cardSize
         switch target {
         case .a:
             let maxOff = maxOffset(for: .a, scale: photoScaleA, cardSize: cardSize)
@@ -103,12 +107,21 @@ extension LenticularVM {
     // MARK: - 아틀라스 합성
 
     /// 사용자 크롭(스케일/오프셋) 적용 후 A+B 아틀라스 합성 → bodyImage에 저장
+    ///
+    /// offset이 `sourceCardSize` 좌표계 기준이므로 `targetSize` 좌표계로 변환이 필요하다.
+    /// `sourceCardSize`는 `applyScale`/`applyOffset` 호출 시 VM이 자동으로 기록한다.
+    /// - Precondition: 호출 전에 사용자가 최소 한 번 이상 카드를 편집했어야 한다 (sourceCardSize 기록).
     func composeAtlas() {
         guard let a = imageA, let b = imageB else { return }
-        let targetSize = KeyringScale.maxSize(for: "Lenticular") // 300×390
+        assert(sourceCardSize != .zero, "composeAtlas 호출 전 sourceCardSize가 기록되지 않음 — applyScale/applyOffset이 먼저 호출되어야 함")
+        let targetSize = KeyringScale.maxSize(for: templateId)
 
         let croppedA = cropImage(a, scale: photoScaleA, offset: photoOffsetA, targetSize: targetSize)
         let croppedB = cropImage(b, scale: photoScaleB, offset: photoOffsetB, targetSize: targetSize)
+
+        // 썸네일 등 편집 결과를 보여주는 뷰에서 재사용
+        croppedImageA = croppedA
+        croppedImageB = croppedB
 
         bodyImage = TextureComposer.compose(
             imageA: croppedA,
@@ -118,6 +131,10 @@ extension LenticularVM {
     }
 
     /// 이미지에 사용자 크롭(스케일/오프셋)을 적용하여 targetSize로 렌더링
+    ///
+    /// 핵심: 사용자의 offset은 `sourceCardSize` 좌표계에서 캡처된 값이므로,
+    /// `targetSize` 좌표계로 그릴 때는 두 fillScale의 비율만큼 변환해야 한다.
+    /// 변환 공식: `convertedOffset = offset × (fillScale_target / fillScale_source)`
     private func cropImage(
         _ image: UIImage,
         scale: CGFloat,
@@ -126,15 +143,29 @@ extension LenticularVM {
     ) -> UIImage {
         let renderer = UIGraphicsImageRenderer(size: targetSize)
         return renderer.image { _ in
+            // target 좌표계의 fillScale (실제 그리기에 사용)
             let fillScale = max(targetSize.width / image.size.width,
                                 targetSize.height / image.size.height)
             let drawSize = CGSize(
                 width: image.size.width * fillScale * scale,
                 height: image.size.height * fillScale * scale
             )
+
+            // source 좌표계의 fillScale (사용자 offset이 기반으로 하는 좌표계)
+            let sourceFillScale = max(sourceCardSize.width / image.size.width,
+                                      sourceCardSize.height / image.size.height)
+            // 두 좌표계 비율 — source → target 변환 계수
+            // sourceCardSize가 아직 기록되지 않았으면 변환 없이 원점에 그림 (이 경우 offset은 .zero일 것)
+            let ratio = sourceFillScale > 0 ? (fillScale / sourceFillScale) : 1.0
+
+            let convertedOffset = CGSize(
+                width: offset.width * ratio,
+                height: offset.height * ratio
+            )
+
             let drawOrigin = CGPoint(
-                x: (targetSize.width - drawSize.width) / 2 + offset.width,
-                y: (targetSize.height - drawSize.height) / 2 + offset.height
+                x: (targetSize.width - drawSize.width) / 2 + convertedOffset.width,
+                y: (targetSize.height - drawSize.height) / 2 + convertedOffset.height
             )
             image.draw(in: CGRect(origin: drawOrigin, size: drawSize))
         }

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM.swift
@@ -55,10 +55,21 @@ class LenticularVM: KeyringViewModelProtocol {
     var photoScaleB: CGFloat = 1.0
     var photoOffsetB: CGSize = .zero
 
+    /// 편집 뷰에서 제스처가 기반으로 하는 카드 크기
+    /// `applyScale`/`applyOffset`이 호출될 때 자동 갱신되며,
+    /// `composeAtlas`가 targetSize 좌표계로 변환할 때 사용한다.
+    var sourceCardSize: CGSize = .zero
+
     // MARK: - Body Image
     /// A+B 가로 합성 아틀라스 (셰이더가 UV로 좌/우 분리 샘플링)
     var bodyImage: UIImage? = nil
     var hookOffsetY: CGFloat = 0.0
+
+    // MARK: - Cropped Images (사용자 편집 반영본)
+    /// 사용자가 선택/편집한 A/B를 아틀라스용으로 크롭한 결과
+    /// FusionView 썸네일 등 편집 결과를 보여줘야 하는 곳에서 사용
+    var croppedImageA: UIImage?
+    var croppedImageB: UIImage?
 
     // MARK: - Info Data
     var nameText: String = ""
@@ -156,7 +167,10 @@ class LenticularVM: KeyringViewModelProtocol {
         photoOffsetA = .zero
         photoScaleB = 1.0
         photoOffsetB = .zero
+        sourceCardSize = .zero
         bodyImage = nil
+        croppedImageA = nil
+        croppedImageB = nil
         selectedShimmerColor = .preset(.silver)
         selectedBorderColor = .preset(.silver)
     }

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/LenticularFusionView+Effects.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/LenticularFusionView+Effects.swift
@@ -91,7 +91,8 @@ extension LenticularFusionView {
             let thumbWidth = cardWidth * FusionLayout.thumbScale
             let thumbHeight = cardHeight * FusionLayout.thumbScale
 
-            if let imageA = viewModel.imageA {
+            // 사용자 편집이 반영된 크롭 이미지만 사용 (원본 폴백 금지 — 기존 버그 재현 방지)
+            if let imageA = viewModel.croppedImageA {
                 Image(uiImage: imageA)
                     .resizable()
                     .scaledToFill()
@@ -105,7 +106,7 @@ extension LenticularFusionView {
                     .opacity(phase == .merge ? 0.0 : (aScale > 0 ? 1.0 : 0.0))
             }
 
-            if let imageB = viewModel.imageB {
+            if let imageB = viewModel.croppedImageB {
                 Image(uiImage: imageB)
                     .resizable()
                     .scaledToFill()


### PR DESCRIPTION
## 🎯 PR 내용
<!-- 무엇을 바꿨는지 간단히/필요하면 길게 -->

### 렌티큘러 이미지 편집 시 크롭 좌표계 오류와 융합뷰 썸네일 미반영 버그 수정

### 원인

  **1. 크롭 좌표계 변환 누락 (`cropImage`)**
  사용자의 `photoOffset`은 편집 카드 좌표계(~314×384)에서 캡처되는데, 
  `cropImage`가 아틀라스 좌표계(220×270)에 offset을 그대로 사용. 
  두 좌표계의 `fillScale`이 달라서 하단으로 최대 드래그 시 캔버스 상단이 비어 보임.

  **2. 융합뷰 썸네일이 원본 참조**
  `thumbnailsLayer`가 raw `viewModel.imageA/imageB`를 그려서 
  사용자 편집(핀치/드래그)이 점프 애니메이션 썸네일에 전혀 반영되지 않음.

  ### 수정

  **1. 좌표계 비율로 offset 변환**

  ```swift
  // source 좌표계(편집 카드)의 fillScale
  let sourceFillScale = max(sourceCardSize.width / image.size.width,
                            sourceCardSize.height / image.size.height)
  // 두 좌표계 변환 계수
  let ratio = sourceFillScale > 0 ? (fillScale / sourceFillScale) : 1.0
  let convertedOffset = CGSize(
      width: offset.width * ratio,
      height: offset.height * ratio
  )
  ```

  `sourceCardSize`는 `applyScale`/`applyOffset` 호출 시 VM이 자동 기록하도록 변경 → 뷰에 `@State`를 두지 않아 MVVM 원칙 준수.

  **2. 썸네일이 `croppedImageA/B`를 사용**

  `composeAtlas()` 실행 시 크롭 결과를 VM에 저장하고, 융합뷰 썸네일이 이를 참조. 
  원본 폴백(`?? imageA`)은 제거 -> 폴백이 살아있으면 버그가 조용히 재현될 수 있음 (fail-fast).


## 📱 스크린샷 (UI 변경 시)
<!-- 필요하면 첨부 -->

https://github.com/user-attachments/assets/dc276d34-11ee-4a87-9c13-627698b1f77c


> 리사이징 잘됨 


## 🔗 관련 이슈
<!-- 현재 이슈와 참고하면 좋은 이슈  -->
- #193 

## ✅ 체크리스트
<!-- 아래 내용을 꼭 체크하고 PR을 날려줘야해요  -->
- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
