### PR TITLE
feat: 렌티큘러 키링 기본 광택테두리 제외 구매로직 추가

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -411,6 +411,7 @@
 		4C7E96382F7D0E9300C8B109 /* KeyringStylePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7E96372F7D0E9300C8B109 /* KeyringStylePreset.swift */; };
 		4C7E963A2F7D0EAB00C8B109 /* StyleSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7E96392F7D0EAB00C8B109 /* StyleSelectorView.swift */; };
 		4C7E963C2F7D267900C8B109 /* KeyringAppearanceColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7E963B2F7D267900C8B109 /* KeyringAppearanceColor.swift */; };
+		4C7E963E2F878FDE00C8B109 /* LenticularVM+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7E963D2F878FDE00C8B109 /* LenticularVM+Style.swift */; };
 		4C8426602ED3585A0050B6FE /* gulimche-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4C84265F2ED3585A0050B6FE /* gulimche-Regular.ttf */; };
 		4C8426642ED375840050B6FE /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8426632ED375840050B6FE /* ColorPalette.swift */; };
 		4C84A1602EB134BD008FFE57 /* ProfileSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596832EAFEAA20003D712 /* ProfileSetupView.swift */; };
@@ -500,6 +501,7 @@
 		4F350E459E3B47DA93E2FFF4 /* BundleSheetToggleButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82FD6112F9442AAAD58DB97 /* BundleSheetToggleButtons.swift */; };
 		8LLA4688ZY3G5NGU9R4ET5A6 /* BundleViewModel+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = U828QC8U2RENQFVCV7ANT8I1 /* BundleViewModel+Types.swift */; };
 		917971D262384EC5AF4D5965 /* BundlePurchaseCartItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E036016318043AC801A19DA /* BundlePurchaseCartItem.swift */; };
+		A73B3E7AC6294154A2605306 /* StylePresetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1A7479E29D45FF9DA9CACA /* StylePresetManager.swift */; };
 		AA0000022F17000100000001 /* BundleSwitchPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000012F17000100000001 /* BundleSwitchPopup.swift */; };
 		AA0213F12F0E000000000001 /* TemplateImageSlideshow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0213F02F0E000000000001 /* TemplateImageSlideshow.swift */; };
 		AA0219DE2EB1C041006EF269 /* BundleNameInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0219DD2EB1C041006EF269 /* BundleNameInputView.swift */; };
@@ -555,7 +557,6 @@
 		C67B755F2ECD526A00D6E3FA /* Frame.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67B755D2ECD526A00D6E3FA /* Frame.swift */; };
 		C6830F042EB8A4000059379A /* WorkshopDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6830F032EB8A4000059379A /* WorkshopDataManager.swift */; };
 		C68931CE2EB7B94B00C5F083 /* EffectManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C68931CC2EB7B94B00C5F083 /* EffectManager.swift */; };
-		A73B3E7AC6294154A2605306 /* StylePresetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1A7479E29D45FF9DA9CACA /* StylePresetManager.swift */; };
 		C6B56F0B2EBC43AC0049F969 /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F0A2EBC43AC0049F969 /* StoreProduct.swift */; };
 		C6B56F112EBD96110049F969 /* CoinChargeView+Purchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F102EBD96110049F969 /* CoinChargeView+Purchase.swift */; };
 		C6B56F132EBD962E0049F969 /* CurrentItemsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F122EBD962E0049F969 /* CurrentItemsCard.swift */; };
@@ -636,6 +637,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2B1A7479E29D45FF9DA9CACA /* StylePresetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylePresetManager.swift; sourceTree = "<group>"; };
 		38173D072EB8AD3900E36F7E /* CollectionViewModel+Tags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CollectionViewModel+Tags.swift"; sourceTree = "<group>"; };
 		38173D092EB8AD7900E36F7E /* CategoryTabBarWithLongPress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTabBarWithLongPress.swift; sourceTree = "<group>"; };
 		38173D0B2EB8AD8800E36F7E /* CategoryContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryContextMenu.swift; sourceTree = "<group>"; };
@@ -1028,6 +1030,7 @@
 		4C7E96372F7D0E9300C8B109 /* KeyringStylePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyringStylePreset.swift; sourceTree = "<group>"; };
 		4C7E96392F7D0EAB00C8B109 /* StyleSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleSelectorView.swift; sourceTree = "<group>"; };
 		4C7E963B2F7D267900C8B109 /* KeyringAppearanceColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyringAppearanceColor.swift; sourceTree = "<group>"; };
+		4C7E963D2F878FDE00C8B109 /* LenticularVM+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LenticularVM+Style.swift"; sourceTree = "<group>"; };
 		4C84265F2ED3585A0050B6FE /* gulimche-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "gulimche-Regular.ttf"; sourceTree = "<group>"; };
 		4C8426632ED375840050B6FE /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		4C86A6112F25C0B10023AA2D /* WorkshopBundleGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkshopBundleGridView.swift; sourceTree = "<group>"; };
@@ -1172,7 +1175,6 @@
 		C67B755D2ECD526A00D6E3FA /* Frame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Frame.swift; sourceTree = "<group>"; };
 		C6830F032EB8A4000059379A /* WorkshopDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkshopDataManager.swift; sourceTree = "<group>"; };
 		C68931CC2EB7B94B00C5F083 /* EffectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectManager.swift; sourceTree = "<group>"; };
-		2B1A7479E29D45FF9DA9CACA /* StylePresetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylePresetManager.swift; sourceTree = "<group>"; };
 		C6B56F0A2EBC43AC0049F969 /* StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProduct.swift; sourceTree = "<group>"; };
 		C6B56F102EBD96110049F969 /* CoinChargeView+Purchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoinChargeView+Purchase.swift"; sourceTree = "<group>"; };
 		C6B56F122EBD962E0049F969 /* CurrentItemsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentItemsCard.swift; sourceTree = "<group>"; };
@@ -2268,6 +2270,7 @@
 			isa = PBXGroup;
 			children = (
 				4C7E95E02F754A0400C8B109 /* LenticularVM.swift */,
+				4C7E963D2F878FDE00C8B109 /* LenticularVM+Style.swift */,
 				4C7E95E12F754A0400C8B109 /* LenticularVM+Effect.swift */,
 				4C7E95E22F754A0400C8B109 /* LenticularVM+Firebase.swift */,
 				4C7E96182F7A0F3300C8B109 /* LenticularVM+ImageLoad.swift */,
@@ -3343,6 +3346,7 @@
 				4CC8D00D2EF030E300317467 /* CollectionViewModel.swift in Sources */,
 				AA8C9B982F10E6D500A352D2 /* BundleViewModel.swift in Sources */,
 				38C3C2882EC1D761003C5DE1 /* CollectionKeyringDetailView+Menu.swift in Sources */,
+				4C7E963E2F878FDE00C8B109 /* LenticularVM+Style.swift in Sources */,
 				4CEC621C2EAE08DA0099ECEE /* BackgroundCell.swift in Sources */,
 				3828F5472EC4CCDC00F1B040 /* CollectionView+NormalMode.swift in Sources */,
 				4CEBB1612EFAD3F800CF53E2 /* MainTabView.swift in Sources */,

--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -555,6 +555,7 @@
 		C67B755F2ECD526A00D6E3FA /* Frame.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67B755D2ECD526A00D6E3FA /* Frame.swift */; };
 		C6830F042EB8A4000059379A /* WorkshopDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6830F032EB8A4000059379A /* WorkshopDataManager.swift */; };
 		C68931CE2EB7B94B00C5F083 /* EffectManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C68931CC2EB7B94B00C5F083 /* EffectManager.swift */; };
+		A73B3E7AC6294154A2605306 /* StylePresetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1A7479E29D45FF9DA9CACA /* StylePresetManager.swift */; };
 		C6B56F0B2EBC43AC0049F969 /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F0A2EBC43AC0049F969 /* StoreProduct.swift */; };
 		C6B56F112EBD96110049F969 /* CoinChargeView+Purchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F102EBD96110049F969 /* CoinChargeView+Purchase.swift */; };
 		C6B56F132EBD962E0049F969 /* CurrentItemsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6B56F122EBD962E0049F969 /* CurrentItemsCard.swift */; };
@@ -1171,6 +1172,7 @@
 		C67B755D2ECD526A00D6E3FA /* Frame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Frame.swift; sourceTree = "<group>"; };
 		C6830F032EB8A4000059379A /* WorkshopDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkshopDataManager.swift; sourceTree = "<group>"; };
 		C68931CC2EB7B94B00C5F083 /* EffectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectManager.swift; sourceTree = "<group>"; };
+		2B1A7479E29D45FF9DA9CACA /* StylePresetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylePresetManager.swift; sourceTree = "<group>"; };
 		C6B56F0A2EBC43AC0049F969 /* StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProduct.swift; sourceTree = "<group>"; };
 		C6B56F102EBD96110049F969 /* CoinChargeView+Purchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoinChargeView+Purchase.swift"; sourceTree = "<group>"; };
 		C6B56F122EBD962E0049F969 /* CurrentItemsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentItemsCard.swift; sourceTree = "<group>"; };
@@ -2979,6 +2981,7 @@
 			children = (
 				4C25262E2F3C95DA003CC5AD /* LottieItemManager.swift */,
 				C68931CC2EB7B94B00C5F083 /* EffectManager.swift */,
+				2B1A7479E29D45FF9DA9CACA /* StylePresetManager.swift */,
 				AA9123AE2ED4BC490070A9F9 /* LocationManager.swift */,
 				38C3C27D2EC08794003C5DE1 /* PopupManager.swift */,
 			);
@@ -3361,6 +3364,7 @@
 				AA3909462EC9F29500D87EEC /* UIApplication+Extension.swift in Sources */,
 				4CC8D0252EF11CD200317467 /* HomeViewModel.swift in Sources */,
 				C68931CE2EB7B94B00C5F083 /* EffectManager.swift in Sources */,
+				A73B3E7AC6294154A2605306 /* StylePresetManager.swift in Sources */,
 				C6B56F202EBF72130049F969 /* ItemPurchaseManager.swift in Sources */,
 				4C5D0BD02F595F5200242703 /* AnimationFrameStorage.swift in Sources */,
 				38818DBC2F3C444300B0A49C /* DuZzonKuVM+Firebase.swift in Sources */,

--- a/Keychy/Keychy/App/KeychyApp.swift
+++ b/Keychy/Keychy/App/KeychyApp.swift
@@ -38,6 +38,11 @@ struct KeychyApp: App {
 
         // 위젯 자동 등록 → 수동 등록 전환 마이그레이션
         KeyringImageCache.shared.migrateToManualWidgetSelectionIfNeeded()
+
+        // 렌티큘러 스타일 프리셋 가격 로드 (Firestore → 메모리)
+        Task {
+            await StylePresetManager.shared.loadPrices()
+        }
     }
     
     // MARK: - Body

--- a/Keychy/Keychy/CommonModels/Keyring/KeyringStylePreset.swift
+++ b/Keychy/Keychy/CommonModels/Keyring/KeyringStylePreset.swift
@@ -71,3 +71,29 @@ enum KeyringStylePreset: String, CaseIterable, Identifiable {
         [.silver, .hologram, .pulse, .cosmos]
     }
 }
+
+// MARK: - 스타일 섹션 구분
+/// 시머/테두리 섹션을 구분하는 enum
+/// - 같은 프리셋이라도 섹션마다 가격이 다를 수 있음 (예: hologram 시머는 1000, 테두리는 500)
+enum StyleSection {
+    case shimmer
+    case border
+}
+
+// MARK: - 가격 / 무료 여부
+extension KeyringStylePreset {
+    /// silver(메탈릭)는 항상 무료
+    var isFree: Bool { self == .silver }
+
+    /// Firestore 가격 로드 실패 시 fallback 가격
+    /// - hologram만 시머/테두리 가격이 다름 (시머 1000, 테두리 500)
+    /// - 그 외 비-silver 프리셋은 모두 500코인
+    func defaultPrice(in section: StyleSection) -> Int {
+        if isFree { return 0 }
+        switch (self, section) {
+        case (.hologram, .shimmer): return 1000
+        case (.hologram, .border):  return 500
+        default:                    return 500
+        }
+    }
+}

--- a/Keychy/Keychy/CommonModels/User/KeychyUser.swift
+++ b/Keychy/Keychy/CommonModels/User/KeychyUser.swift
@@ -23,6 +23,8 @@ struct KeychyUser: Identifiable {
     var chains: [String]
     var soundEffects: [String]
     var particleEffects: [String]
+    var ownedShimmerEffects: [String]  // 구매한 렌티큘러 시머 효과 프리셋 ID 배열
+    var ownedBorderEffects: [String]   // 구매한 렌티큘러 테두리 효과 프리셋 ID 배열
     var backgrounds: [String]
     var carabiners: [String]
     var tags: [String]
@@ -46,6 +48,8 @@ struct KeychyUser: Identifiable {
             "chains": chains,
             "soundEffects": soundEffects,
             "particleEffects": particleEffects,
+            "ownedShimmerEffects": ownedShimmerEffects,
+            "ownedBorderEffects": ownedBorderEffects,
             "backgrounds": backgrounds,
             "carabiners": carabiners,
             "tags": tags,
@@ -77,6 +81,8 @@ struct KeychyUser: Identifiable {
         self.chains = data["chains"] as? [String] ?? []
         self.soundEffects = data["soundEffects"] as? [String] ?? []
         self.particleEffects = data["particleEffects"] as? [String] ?? []
+        self.ownedShimmerEffects = data["ownedShimmerEffects"] as? [String] ?? []
+        self.ownedBorderEffects = data["ownedBorderEffects"] as? [String] ?? []
         self.backgrounds = data["backgrounds"] as? [String] ?? []
         self.carabiners = data["carabiners"] as? [String] ?? []
         self.tags = data["tags"] as? [String] ?? []
@@ -101,6 +107,8 @@ struct KeychyUser: Identifiable {
         self.chains = []
         self.soundEffects = []
         self.particleEffects = []
+        self.ownedShimmerEffects = []
+        self.ownedBorderEffects = []
         self.backgrounds = []
         self.carabiners = []
         self.tags = []

--- a/Keychy/Keychy/Core/FileManagers/StylePresetManager.swift
+++ b/Keychy/Keychy/Core/FileManagers/StylePresetManager.swift
@@ -1,0 +1,72 @@
+//
+//  StylePresetManager.swift
+//  Keychy
+//
+//  Created by 길지훈 on 2026-04-09.
+//
+//  렌티큘러 스타일 프리셋(시머/테두리)의 가격 로드 + 소유 여부 관리
+//  - EffectManager.isOwned(soundId:) / (particleId:) 패턴을 미러링
+//  - 가격은 Firestore의 Template/Lenticular 하위 서브컬렉션에서 로드
+//    (ShimmerEffects / BorderEffects)
+//  - 로드 실패 시 KeyringStylePreset.defaultPrice(in:) fallback 사용
+//
+
+import Foundation
+import FirebaseFirestore
+
+@MainActor
+@Observable
+final class StylePresetManager {
+    static let shared = StylePresetManager()
+
+    /// 시머 프리셋 ID → 가격
+    private var shimmerPrices: [String: Int] = [:]
+    /// 테두리 프리셋 ID → 가격
+    private var borderPrices: [String: Int] = [:]
+
+    private let db = Firestore.firestore()
+
+    private init() {}
+
+    // MARK: - 가격 로드
+    /// 앱 시작 시 한 번 호출하여 Firestore에서 가격 정보를 메모리에 적재
+    /// 경로: `Template/Lenticular/ShimmerEffects`, `Template/Lenticular/BorderEffects`
+    func loadPrices() async {
+        let lenticularDoc = db.collection("Template").document("Lenticular")
+
+        do {
+            // 시머 가격
+            let shimmerSnap = try await lenticularDoc.collection("ShimmerEffects").getDocuments()
+            shimmerPrices = Dictionary(uniqueKeysWithValues: shimmerSnap.documents.compactMap {
+                guard let price = $0.data()["price"] as? Int else { return nil }
+                return ($0.documentID, price)
+            })
+
+            // 테두리 가격
+            let borderSnap = try await lenticularDoc.collection("BorderEffects").getDocuments()
+            borderPrices = Dictionary(uniqueKeysWithValues: borderSnap.documents.compactMap {
+                guard let price = $0.data()["price"] as? Int else { return nil }
+                return ($0.documentID, price)
+            })
+        } catch {
+            // 실패 시 빈 dict 유지 → defaultPrice fallback이 작동
+        }
+    }
+
+    // MARK: - 가격 조회
+    /// 프리셋 가격 조회 (Firestore → fallback 순서)
+    func price(for preset: KeyringStylePreset, in section: StyleSection) -> Int {
+        if preset.isFree { return 0 }
+        let firestoreValue = (section == .shimmer ? shimmerPrices : borderPrices)[preset.rawValue]
+        return firestoreValue ?? preset.defaultPrice(in: section)
+    }
+
+    // MARK: - 소유 여부
+    /// 무료 프리셋(silver)은 owned 배열에 없어도 사용 가능 → 별도 isFree 분기 필요
+    /// (EffectManager.isOwned 패턴과 동일하게 무료/소유 검사를 분리)
+    func isOwned(preset: KeyringStylePreset, in section: StyleSection, userManager: UserManager) -> Bool {
+        guard let user = userManager.currentUser else { return false }
+        let owned = section == .shimmer ? user.ownedShimmerEffects : user.ownedBorderEffects
+        return owned.contains(preset.rawValue)
+    }
+}

--- a/Keychy/Keychy/Core/Firebase/DataInitializer.swift
+++ b/Keychy/Keychy/Core/Firebase/DataInitializer.swift
@@ -204,6 +204,46 @@ func initializeSounds() async {
     await uploadItems(sounds, collection: "Sound")
 }
 
+// MARK: - ShimmerEffects (렌티큘러 시머)
+
+/// 렌티큘러 시머(광택) 프리셋 가격 Firestore 업로드
+///
+/// 경로: `Template/Lenticular/ShimmerEffects/{id}`
+///
+/// 필수 필드:
+/// - id: 프리셋 rawValue (예: "hologram", "liquid", "matrix")
+/// - price: 가격 (0 = 무료)
+///
+/// silver는 하드코딩 무료라 컬렉션에 넣지 않음.
+func initializeShimmerEffects() async {
+    let items: [[String: Any]] = [
+        ["id": "hologram", "price": 1000],
+        ["id": "liquid",   "price": 500],
+        ["id": "matrix",   "price": 500],
+    ]
+    await uploadItems(items, collection: "ShimmerEffects", parentPath: "Template/Lenticular")
+}
+
+// MARK: - BorderEffects (렌티큘러 테두리)
+
+/// 렌티큘러 테두리 프리셋 가격 Firestore 업로드
+///
+/// 경로: `Template/Lenticular/BorderEffects/{id}`
+///
+/// 필수 필드:
+/// - id: 프리셋 rawValue (예: "hologram", "pulse", "cosmos")
+/// - price: 가격 (0 = 무료)
+///
+/// silver는 하드코딩 무료라 컬렉션에 넣지 않음.
+func initializeBorderEffects() async {
+    let items: [[String: Any]] = [
+        ["id": "hologram", "price": 500],
+        ["id": "pulse",    "price": 500],
+        ["id": "cosmos",   "price": 500],
+    ]
+    await uploadItems(items, collection: "BorderEffects", parentPath: "Template/Lenticular")
+}
+
 // MARK: - Template
 
 /// 템플릿 Firestore 업로드
@@ -241,13 +281,34 @@ func initializeTemplates() async {
 /// 아이템 배열을 Firestore에 업로드
 /// - 문서가 없으면 createdAt 자동 추가
 /// - merge: true로 기존 필드 보존
-private func uploadItems(_ items: [[String: Any]], collection: String) async {
+///
+/// - Parameters:
+///   - items: 업로드할 아이템 배열 (각 dict에 "id" 키 필수)
+///   - collection: 대상 컬렉션 이름
+///   - parentPath: 서브컬렉션으로 넣을 때 부모 경로 (예: "Template/Lenticular").
+///                 nil이면 루트 컬렉션에 업로드.
+private func uploadItems(
+    _ items: [[String: Any]],
+    collection: String,
+    parentPath: String? = nil
+) async {
     guard !items.isEmpty else {
         print("[\(collection)] 업로드할 아이템이 없습니다.")
         return
     }
 
     let db = Firestore.firestore()
+
+    // parentPath가 있으면 서브컬렉션 참조, 없으면 루트 컬렉션 참조
+    let targetCollection: CollectionReference = {
+        guard let parentPath, !parentPath.isEmpty else {
+            return db.collection(collection)
+        }
+        return db.document(parentPath).collection(collection)
+    }()
+
+    // 로그 prefix (서브컬렉션이면 전체 경로 표시)
+    let logPrefix = parentPath.map { "\($0)/\(collection)" } ?? collection
 
     for item in items {
         guard let id = item["id"] as? String else { continue }
@@ -256,16 +317,16 @@ private func uploadItems(_ items: [[String: Any]], collection: String) async {
         data.removeValue(forKey: "id")
 
         do {
-            let doc = try await db.collection(collection).document(id).getDocument()
+            let doc = try await targetCollection.document(id).getDocument()
 
             if !doc.exists {
                 data["createdAt"] = Timestamp(date: Date())
             }
 
-            try await db.collection(collection).document(id).setData(data, merge: true)
-            print("[\(collection)] \(id) 업로드 완료")
+            try await targetCollection.document(id).setData(data, merge: true)
+            print("[\(logPrefix)] \(id) 업로드 완료")
         } catch {
-            print("[\(collection)] \(id) 오류: \(error)")
+            print("[\(logPrefix)] \(id) 오류: \(error)")
         }
     }
 }

--- a/Keychy/Keychy/Core/Keyring/Scene/KeyringScene/KeyringScene.swift
+++ b/Keychy/Keychy/Core/Keyring/Scene/KeyringScene/KeyringScene.swift
@@ -157,7 +157,7 @@ class KeyringScene: SKScene {
             .store(in: &cancellables)
 
         // 렌티큘러 등 자이로 템플릿: 초기 스타일(시머/테두리) 적용
-        // - 편집 중(LenticularVM): selectedShimmerColor.firestoreId 반환
+        // - 편집 중(LenticularVM): selectedShimmerEffect.firestoreId 반환
         // - 영상 생성 시(KeyringAdapter): 저장된 Keyring 모델의 ID 반환
         // 어느 경로든 `KeyringAppearanceColor.from(id:)`로 nil-safe 복원 가능
         if viewModel.isGyroscope {

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Models/EffectItem.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Models/EffectItem.swift
@@ -2,18 +2,27 @@
 //  EffectItem.swift
 //  Keychy
 //
-//  장바구니용 이펙트 아이템 모델
+//  키링 커스터마이징 화면에서 카트에 담기는 아이템
 //
 
 import Foundation
 
-/// 장바구니에 담기는 이펙트 아이템 (Sound 또는 Particle)
+/// 장바구니에 담기는 이펙트 아이템
+/// - 사운드 / 파티클 / 렌티큘러 시머 / 렌티큘러 테두리 모두 표현 가능
 struct EffectItem: Identifiable, Equatable {
     let id: String
     let name: String
     let type: EffectType
     let price: Int
     let thumbnailURL: String
+
+    /// SwiftUI ForEach 등에서 안전하게 식별할 수 있는 합성 키
+    /// - `id`만 쓰면 시머 hologram(id="hologram")과 테두리 hologram(id="hologram")이
+    ///   같은 식별자가 되어 ForEach가 중복 제거해버린다.
+    /// - type을 prefix로 붙여 (시머 hologram) ≠ (테두리 hologram) 보장.
+    var uniqueId: String {
+        "\(type.rawValue)_\(id)"
+    }
 
     /// Sound 모델에서 EffectItem 생성
     init(sound: Sound) {
@@ -32,10 +41,30 @@ struct EffectItem: Identifiable, Equatable {
         self.price = particle.price
         self.thumbnailURL = particle.thumbnail
     }
+
+    /// 렌티큘러 시머 효과 프리셋에서 EffectItem 생성
+    init(shimmerEffect preset: KeyringStylePreset, price: Int) {
+        self.id = preset.rawValue
+        self.name = preset.displayName
+        self.type = .shimmerEffect
+        self.price = price
+        self.thumbnailURL = ""
+    }
+
+    /// 렌티큘러 테두리 효과 프리셋에서 EffectItem 생성
+    init(borderEffect preset: KeyringStylePreset, price: Int) {
+        self.id = preset.rawValue
+        self.name = preset.displayName
+        self.type = .borderEffect
+        self.price = price
+        self.thumbnailURL = ""
+    }
 }
 
-/// 이펙트 타입
+/// 이펙트 타입 (Receipt itemType으로도 사용됨)
 enum EffectType: String {
     case sound = "사운드"
     case particle = "파티클"
+    case shimmerEffect = "렌티큘러 광택"
+    case borderEffect = "렌티큘러 테두리"
 }

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCompleteView+SaveImage.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCompleteView+SaveImage.swift
@@ -30,8 +30,8 @@ extension KeyringCompleteView {
             zoomScale: 2.0,
             hookOffsetY: viewModel.hookOffsetY != 0 ? viewModel.hookOffsetY : nil,
             chainLength: viewModel.chainLength,
-            shimmerColorId: (viewModel as? LenticularVM)?.selectedShimmerColor.firestoreId,
-            borderColorId: (viewModel as? LenticularVM)?.selectedBorderColor.firestoreId
+            shimmerColorId: (viewModel as? LenticularVM)?.selectedShimmerEffect.firestoreId,
+            borderColorId: (viewModel as? LenticularVM)?.selectedBorderEffect.firestoreId
         )
         scene.scaleMode = .aspectFill
 

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+Cart.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+Cart.swift
@@ -29,28 +29,6 @@ extension KeyringCustomizingView {
         cartItems.append(item)
     }
 
-    /// 렌티큘러 시머 효과를 장바구니에 추가 (시머는 1개만 담을 수 있음)
-    func addShimmerEffectToCart(_ preset: KeyringStylePreset, price: Int) {
-        cartItems.removeAll { $0.type == .shimmerEffect }
-        cartItems.append(EffectItem(shimmerEffect: preset, price: price))
-    }
-
-    /// 렌티큘러 테두리 효과를 장바구니에 추가 (테두리는 1개만 담을 수 있음)
-    func addBorderEffectToCart(_ preset: KeyringStylePreset, price: Int) {
-        cartItems.removeAll { $0.type == .borderEffect }
-        cartItems.append(EffectItem(borderEffect: preset, price: price))
-    }
-
-    /// 장바구니에서 시머 효과 제거
-    func removeShimmerEffectFromCart() {
-        cartItems.removeAll { $0.type == .shimmerEffect }
-    }
-
-    /// 장바구니에서 테두리 효과 제거
-    func removeBorderEffectFromCart() {
-        cartItems.removeAll { $0.type == .borderEffect }
-    }
-
     /// 장바구니에서 아이템 제거
     func removeFromCart(_ itemId: String) {
         cartItems.removeAll { $0.id == itemId }

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+Cart.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+Cart.swift
@@ -29,6 +29,28 @@ extension KeyringCustomizingView {
         cartItems.append(item)
     }
 
+    /// 렌티큘러 시머 효과를 장바구니에 추가 (시머는 1개만 담을 수 있음)
+    func addShimmerEffectToCart(_ preset: KeyringStylePreset, price: Int) {
+        cartItems.removeAll { $0.type == .shimmerEffect }
+        cartItems.append(EffectItem(shimmerEffect: preset, price: price))
+    }
+
+    /// 렌티큘러 테두리 효과를 장바구니에 추가 (테두리는 1개만 담을 수 있음)
+    func addBorderEffectToCart(_ preset: KeyringStylePreset, price: Int) {
+        cartItems.removeAll { $0.type == .borderEffect }
+        cartItems.append(EffectItem(borderEffect: preset, price: price))
+    }
+
+    /// 장바구니에서 시머 효과 제거
+    func removeShimmerEffectFromCart() {
+        cartItems.removeAll { $0.type == .shimmerEffect }
+    }
+
+    /// 장바구니에서 테두리 효과 제거
+    func removeBorderEffectFromCart() {
+        cartItems.removeAll { $0.type == .borderEffect }
+    }
+
     /// 장바구니에서 아이템 제거
     func removeFromCart(_ itemId: String) {
         cartItems.removeAll { $0.id == itemId }

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+Purchase.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+Purchase.swift
@@ -46,14 +46,23 @@ extension KeyringCustomizingView {
             return
         }
 
-        // 3. Firebase 트랜잭션 처리
+        // 3. UI 피드백 먼저: 시트 닫고 프로그레스 즉시 등장
+        // -> 트랜잭션/영수증 저장 전에 띄워야 클릭 → 로딩 사이의 체감 텀이 사라짐
+        await MainActor.run {
+            showPurchaseSheet = false
+            showPurchaseProgress = true
+        }
+
+        // 4. Firebase 트랜잭션 처리
         let db = Firestore.firestore()
         let userRef = db.collection("User").document(userId)
 
         do {
-            // 장바구니 아이템을 사운드/파티클로 분리
+            // 장바구니 아이템을 타입별로 분리
             let soundIds = cartItems.filter { $0.type == .sound }.map { $0.id }
             let particleIds = cartItems.filter { $0.type == .particle }.map { $0.id }
+            let shimmerEffectIds = cartItems.filter { $0.type == .shimmerEffect }.map { $0.id }
+            let borderEffectIds = cartItems.filter { $0.type == .borderEffect }.map { $0.id }
 
             // 배치 업데이트 (원자성 보장)
             try await db.runTransaction { (transaction, errorPointer) -> Any? in
@@ -92,20 +101,39 @@ extension KeyringCustomizingView {
                     updates["particleEffects"] = FieldValue.arrayUnion(particleIds)
                 }
 
+                // 렌티큘러 시머 효과 소유 목록 추가
+                if !shimmerEffectIds.isEmpty {
+                    updates["ownedShimmerEffects"] = FieldValue.arrayUnion(shimmerEffectIds)
+                }
+
+                // 렌티큘러 테두리 효과 소유 목록 추가
+                if !borderEffectIds.isEmpty {
+                    updates["ownedBorderEffects"] = FieldValue.arrayUnion(borderEffectIds)
+                }
+
                 // 한 번에 업데이트!
                 transaction.updateData(updates, forDocument: userRef)
 
                 return "success"
             }
 
-            // 4. 시트 닫고 구매 중 프로그레스 표시
-            await MainActor.run {
-                showPurchaseSheet = false
-                showPurchaseProgress = true
+            // 5. 트랜잭션 성공 → 영수증을 batch로 한 번의 네트워크 왕복에 묶어서 저장
+            // ⚠️ 영수증 저장 실패는 결제 실패로 처리하지 않음 (트랜잭션은 이미 커밋됨)
+            // try?로 silently 무시 — 추적성은 잃지만 사용자 결제 성공은 깨지지 않음
+            // (ItemPurchaseManager.saveReceipt와 동일한 정책)
+            let batch = db.batch()
+            for item in cartItems {
+                let receiptRef = userRef.collection("Receipts").document()
+                let receiptData: [String: Any] = [
+                    "itemID":      item.id,
+                    "itemName":    item.name,
+                    "itemType":    item.type.rawValue,
+                    "price":       item.price,
+                    "purchasedAt": Timestamp(date: Date())
+                ]
+                batch.setData(receiptData, forDocument: receiptRef)
             }
-
-            // 5. Firebase 커밋이 완전히 완료될 때까지 대기
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            try? await batch.commit()
 
             // 6. UserManager만 갱신 (fetchEffects 호출하지 않음)
             // -> fetchEffects()를 호출하면 소유/미소유로 리스트가 재배열되어 ForEach가 재구성됨
@@ -113,8 +141,8 @@ extension KeyringCustomizingView {
             // -> UserManager만 갱신하면 isOwned() 체크만 업데이트되어 UI 스타일만 변경됨
             UserManager.shared.loadUserInfo(uid: userId) { _ in }
 
-            // 7. UserManager 갱신 완료 대기
-            try? await Task.sleep(nanoseconds: 500_000_000)
+            // 7. UserManager 갱신 settle 대기 (loadUserInfo는 콜백 기반이라 짧게 대기)
+            try? await Task.sleep(nanoseconds: 300_000_000)
 
             // 8. UI 업데이트 (프로그레스 닫고 성공 Alert 표시 및 장바구니 비우기)
             await MainActor.run {

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+PurchaseSheet.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView+PurchaseSheet.swift
@@ -32,7 +32,7 @@ extension KeyringCustomizingView {
             /// 장바구니 리스트 (스크롤 가능)
             ScrollView {
                 VStack(spacing: 20) {
-                    ForEach(cartItems) { item in
+                    ForEach(cartItems, id: \.uniqueId) { item in
                         purchaseItemRow(item: item)
                     }
                 }

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+FirebaseSave.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringInfoInputView+FirebaseSave.swift
@@ -60,15 +60,15 @@ extension KeyringInfoInputView {
         let templateId = viewModel.templateId
         let isGyroscope = viewModel.isGyroscope
 
-        // 렌티큘러 VM이면 시머/테두리 색상 ID 추출 (기본값 silver면 nil로 저장하여 용량 절약)
+        // 렌티큘러 VM이면 시머/테두리 효과 ID 추출 (기본값 silver면 nil로 저장하여 용량 절약)
         let shimmerColorId: String? = (viewModel as? LenticularVM)
             .flatMap { vm -> String? in
-                let id = vm.selectedShimmerColor.firestoreId
+                let id = vm.selectedShimmerEffect.firestoreId
                 return id == "silver" ? nil : id
             }
         let borderColorId: String? = (viewModel as? LenticularVM)
             .flatMap { vm -> String? in
-                let id = vm.selectedBorderColor.firestoreId
+                let id = vm.selectedBorderEffect.firestoreId
                 return id == "silver" ? nil : id
             }
 

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM+ImageLoad.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM+ImageLoad.swift
@@ -110,10 +110,10 @@ extension LenticularVM {
     ///
     /// offset이 `sourceCardSize` 좌표계 기준이므로 `targetSize` 좌표계로 변환이 필요하다.
     /// `sourceCardSize`는 `applyScale`/`applyOffset` 호출 시 VM이 자동으로 기록한다.
-    /// - Precondition: 호출 전에 사용자가 최소 한 번 이상 카드를 편집했어야 한다 (sourceCardSize 기록).
+    /// 사용자가 카드를 한 번도 편집하지 않으면 `sourceCardSize`가 `.zero`로 남는데,
+    /// 이 경우 `cropImage`가 폴백 처리하여 기본 위치(중앙 정렬)로 그린다.
     func composeAtlas() {
         guard let a = imageA, let b = imageB else { return }
-        assert(sourceCardSize != .zero, "composeAtlas 호출 전 sourceCardSize가 기록되지 않음 — applyScale/applyOffset이 먼저 호출되어야 함")
         let targetSize = KeyringScale.maxSize(for: templateId)
 
         let croppedA = cropImage(a, scale: photoScaleA, offset: photoOffsetA, targetSize: targetSize)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM+Style.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM+Style.swift
@@ -1,0 +1,115 @@
+//
+//  LenticularVM+Style.swift
+//  Keychy
+//
+//  Created by 길지훈 on 2026-04-09.
+//
+//  렌티큘러 시머/테두리 프리셋 선택 + 카트/소유/가격 조회 + 틴트 색상 변환
+//  StyleSelectorView가 호출하는 모든 비즈니스 로직을 담당.
+//
+
+import SwiftUI
+
+extension LenticularVM {
+    // MARK: - 소유/가격 조회
+    /// View가 StylePresetManager를 직접 호출하지 않도록 VM이 중계
+
+    func isShimmerOwned(_ preset: KeyringStylePreset) -> Bool {
+        StylePresetManager.shared.isOwned(
+            preset: preset, in: .shimmer, userManager: userManager
+        )
+    }
+
+    func isBorderOwned(_ preset: KeyringStylePreset) -> Bool {
+        StylePresetManager.shared.isOwned(
+            preset: preset, in: .border, userManager: userManager
+        )
+    }
+
+    func shimmerPrice(_ preset: KeyringStylePreset) -> Int {
+        StylePresetManager.shared.price(for: preset, in: .shimmer)
+    }
+
+    func borderPrice(_ preset: KeyringStylePreset) -> Int {
+        StylePresetManager.shared.price(for: preset, in: .border)
+    }
+
+    // MARK: - 시머/테두리 선택 (3-way 분기)
+    /// 시머 프리셋 선택
+    /// - 무료 or 보유 → 즉시 적용 + 카트에서 시머 제거
+    /// - 미보유 유료 + 이미 선택됨 → 선택 해제 (silver로 폴백)
+    /// - 미보유 유료 + 미선택 → 카트 추가 + 미리보기 적용
+    func selectShimmerEffect(
+        preset: KeyringStylePreset,
+        cartItems: Binding<[EffectItem]>
+    ) {
+        let isUsable = preset.isFree || isShimmerOwned(preset)
+        let isCurrentlySelected = selectedShimmerEffect.activePreset == preset
+
+        if isUsable {
+            updateShimmerEffect(.preset(preset))
+            cartItems.wrappedValue.removeAll { $0.type == .shimmerEffect }
+        } else if isCurrentlySelected {
+            updateShimmerEffect(.preset(.silver))
+            cartItems.wrappedValue.removeAll { $0.type == .shimmerEffect }
+        } else {
+            cartItems.wrappedValue.removeAll { $0.type == .shimmerEffect }
+            cartItems.wrappedValue.append(
+                EffectItem(shimmerEffect: preset, price: shimmerPrice(preset))
+            )
+            updateShimmerEffect(.preset(preset))
+        }
+    }
+
+    /// 테두리 프리셋 선택 (시머와 동일한 3-way 분기)
+    func selectBorderEffect(
+        preset: KeyringStylePreset,
+        cartItems: Binding<[EffectItem]>
+    ) {
+        let isUsable = preset.isFree || isBorderOwned(preset)
+        let isCurrentlySelected = selectedBorderEffect.activePreset == preset
+
+        if isUsable {
+            updateBorderEffect(.preset(preset))
+            cartItems.wrappedValue.removeAll { $0.type == .borderEffect }
+        } else if isCurrentlySelected {
+            updateBorderEffect(.preset(.silver))
+            cartItems.wrappedValue.removeAll { $0.type == .borderEffect }
+        } else {
+            cartItems.wrappedValue.removeAll { $0.type == .borderEffect }
+            cartItems.wrappedValue.append(
+                EffectItem(borderEffect: preset, price: borderPrice(preset))
+            )
+            updateBorderEffect(.preset(preset))
+        }
+    }
+
+    // MARK: - 틴트 색상 변환 (Color ↔ 셰이더 RGB)
+
+    /// ColorPicker getter용: 셰이더 RGB → SwiftUI Color
+    func shimmerTintColor() -> Color {
+        let c = selectedShimmerEffect.shaderColor
+        return Color(red: Double(c.r), green: Double(c.g), blue: Double(c.b))
+    }
+
+    func borderTintColor() -> Color {
+        let c = selectedBorderEffect.shaderColor
+        return Color(red: Double(c.r), green: Double(c.g), blue: Double(c.b))
+    }
+
+    /// ColorPicker setter용: Color → UIColor → 셰이더 RGB → VM 업데이트
+    /// hologram은 색상 변경 불가 (셰이더가 자체 무지개 그라데이션 사용)
+    func updateShimmerTint(color: Color) {
+        let mode = selectedShimmerEffect.activePreset
+        guard mode != .hologram else { return }
+        let c = UIColor(color).rgbComponents
+        updateShimmerEffect(.customTint(mode: mode, r: c.r, g: c.g, b: c.b))
+    }
+
+    func updateBorderTint(color: Color) {
+        let mode = selectedBorderEffect.activePreset
+        guard mode != .hologram else { return }
+        let c = UIColor(color).rgbComponents
+        updateBorderEffect(.customTint(mode: mode, r: c.r, g: c.g, b: c.b))
+    }
+}

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/ViewModels/LenticularVM.swift
@@ -28,10 +28,10 @@ class LenticularVM: KeyringViewModelProtocol {
     let effectSubject = PassthroughSubject<(soundId: String, particleId: String, type: KeyringUpdateType), Never>()
 
     // MARK: - Style Data (시머 + 테두리 분리)
-    /// 선택된 시머(광택) 색상
-    var selectedShimmerColor: KeyringAppearanceColor = .preset(.silver)
-    /// 선택된 테두리 색상
-    var selectedBorderColor: KeyringAppearanceColor = .preset(.silver)
+    /// 선택된 시머(광택) 효과
+    var selectedShimmerEffect: KeyringAppearanceColor = .preset(.silver)
+    /// 선택된 테두리 효과
+    var selectedBorderEffect: KeyringAppearanceColor = .preset(.silver)
 
     /// Scene에 스타일 변경을 전달하는 Subject
     struct StyleUpdate {
@@ -92,12 +92,14 @@ class LenticularVM: KeyringViewModelProtocol {
     var isGyroscope: Bool { template?.interactions.contains("tilt") ?? true }
 
     // MARK: - KeyringViewModelProtocol: Style ID (렌티큘러 전용)
-    /// 시머 색상 ID — KeyringScene이 초기 스타일 적용 시 참조
+    /// 시머 효과 ID — KeyringScene이 초기 스타일 적용 시 참조
     /// 실시간 편집 업데이트는 `styleSubject`를 통해 별도로 처리됨
-    var shimmerColorId: String? { selectedShimmerColor.firestoreId }
+    /// (이름이 `Color`인 이유: `Keyring.shimmerColorId` Firestore 필드와 라벨을 맞추기 위함)
+    var shimmerColorId: String? { selectedShimmerEffect.firestoreId }
 
-    /// 테두리 색상 ID — KeyringScene이 초기 스타일 적용 시 참조
-    var borderColorId: String? { selectedBorderColor.firestoreId }
+    /// 테두리 효과 ID — KeyringScene이 초기 스타일 적용 시 참조
+    /// (이름이 `Color`인 이유: `Keyring.borderColorId` Firestore 필드와 라벨을 맞추기 위함)
+    var borderColorId: String? { selectedBorderEffect.firestoreId }
 
     // MARK: - Customizing Modes
     /// 렌티큘러: 시머 색상 선택 + 이펙트
@@ -109,16 +111,16 @@ class LenticularVM: KeyringViewModelProtocol {
     }
 
     // MARK: - Style Update (시머/테두리)
-    /// 시머(광택) 색상 변경 → Scene에 실시간 반영
-    func updateShimmerColor(_ color: KeyringAppearanceColor) {
-        selectedShimmerColor = color
-        styleSubject.send(StyleUpdate(shimmer: selectedShimmerColor, border: selectedBorderColor))
+    /// 시머(광택) 효과 변경 → Scene에 실시간 반영
+    func updateShimmerEffect(_ effect: KeyringAppearanceColor) {
+        selectedShimmerEffect = effect
+        styleSubject.send(StyleUpdate(shimmer: selectedShimmerEffect, border: selectedBorderEffect))
     }
 
-    /// 테두리 색상 변경 → Scene에 실시간 반영
-    func updateBorderColor(_ color: KeyringAppearanceColor) {
-        selectedBorderColor = color
-        styleSubject.send(StyleUpdate(shimmer: selectedShimmerColor, border: selectedBorderColor))
+    /// 테두리 효과 변경 → Scene에 실시간 반영
+    func updateBorderEffect(_ effect: KeyringAppearanceColor) {
+        selectedBorderEffect = effect
+        styleSubject.send(StyleUpdate(shimmer: selectedShimmerEffect, border: selectedBorderEffect))
     }
 
     // MARK: - View Providers
@@ -135,7 +137,7 @@ class LenticularVM: KeyringViewModelProtocol {
     ) -> AnyView {
         switch mode {
         case .style:
-            return AnyView(StyleSelectorView(viewModel: self))
+            return AnyView(StyleSelectorView(viewModel: self, cartItems: cartItems))
         case .effect:
             return AnyView(EffectSelectorView(viewModel: self, cartItems: cartItems))
         default:
@@ -171,8 +173,8 @@ class LenticularVM: KeyringViewModelProtocol {
         bodyImage = nil
         croppedImageA = nil
         croppedImageB = nil
-        selectedShimmerColor = .preset(.silver)
-        selectedBorderColor = .preset(.silver)
+        selectedShimmerEffect = .preset(.silver)
+        selectedBorderEffect = .preset(.silver)
     }
 
     func resetInfoData() {

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/LenticularFusionView+Animation.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/LenticularFusionView+Animation.swift
@@ -246,8 +246,8 @@ extension LenticularFusionView {
         // .resizeFill을 쓰면 좌표계가 변경되어 셰이더 SDF 테두리가 편향됨
         scene.scaleMode = .aspectFill
 
-        let shimmerPreset = viewModel.selectedShimmerColor
-        let borderPreset = viewModel.selectedBorderColor
+        let shimmerPreset = viewModel.selectedShimmerEffect
+        let borderPreset = viewModel.selectedBorderEffect
         let bodyNode = KeyringBodyComponent.createLenticularBody(
             atlasImage: bodyImage,
             templateId: templateId,

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/StyleSelectorView+Previews.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/StyleSelectorView+Previews.swift
@@ -9,14 +9,24 @@ import SwiftUI
 
 // MARK: - 프리셋 셀
 extension StyleSelectorView {
+    /// 프리셋 셀 — 미보유 유료 시각 표시
+    /// - 무료 또는 보유 + 선택됨 → `.main500` 테두리 (기존)
+    /// - 미보유 유료 + 선택됨(카트 대기) → 그라데이션 테두리
+    /// - 미보유 유료 + 미선택 → 우상단에 작은 코인 아이콘 (가격 숫자는 카트에서 확인)
     @ViewBuilder
     func presetCell(
         preset: KeyringStylePreset,
         isSelected: Bool,
-        onSelect: @escaping (KeyringAppearanceColor) -> Void
+        isOwned: Bool,
+        onSelect: @escaping (KeyringStylePreset) -> Void
     ) -> some View {
+        // 시각 분기 (EffectSelectorView 패턴 차용)
+        let isPaid = !preset.isFree && !isOwned
+        let isPaidUnownedSelected = isPaid && isSelected   // 카트 대기 상태
+        let showCoinBadge = isPaid && !isSelected          // 미선택 유료 → 코인 아이콘 표시
+
         Button {
-            onSelect(.preset(preset))
+            onSelect(preset)
         } label: {
             VStack(spacing: 6) {
                 presetCircle(for: preset)
@@ -26,10 +36,30 @@ extension StyleSelectorView {
                         Circle().strokeBorder(Color.black20, lineWidth: 0.5)
                     )
                     .overlay(
-                        Circle()
-                            .strokeBorder(.main500, lineWidth: isSelected ? 2.5 : 0)
-                            .frame(width: 46, height: 46)
+                        // 선택 테두리: 카트 대기 = gradient, 그 외 = main500
+                        Group {
+                            if isPaidUnownedSelected {
+                                Circle()
+                                    .strokeBorder(.gradient(.primary), lineWidth: 2.5)
+                                    .frame(width: 46, height: 46)
+                            } else if isSelected {
+                                Circle()
+                                    .strokeBorder(.main500, lineWidth: 2.5)
+                                    .frame(width: 46, height: 46)
+                            }
+                        }
                     )
+                    .overlay(alignment: .topTrailing) {
+                        // 코인 아이콘 뱃지: 미보유 유료 + 미선택 시
+                        if showCoinBadge {
+                            Image(.myCoinMini)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 14, height: 14)
+                                .padding(2)
+                                .offset(x: 4, y: -4)
+                        }
+                    }
 
                 Text(preset.displayName)
                     .typography(.suit12M)

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/StyleSelectorView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/StyleSelectorView.swift
@@ -28,7 +28,7 @@ struct StyleSelectorView: View {
                 presets: KeyringStylePreset.shimmerPresets,
                 selected: viewModel.selectedShimmerEffect,
                 tintBinding: shimmerTintBinding(),
-                onSelect: { handleShimmerSelect(preset: $0) }
+                onSelect: { viewModel.selectShimmerEffect(preset: $0, cartItems: $cartItems) }
             )
 
             styleSection(
@@ -37,7 +37,7 @@ struct StyleSelectorView: View {
                 presets: KeyringStylePreset.borderPresets,
                 selected: viewModel.selectedBorderEffect,
                 tintBinding: borderTintBinding(),
-                onSelect: { handleBorderSelect(preset: $0) }
+                onSelect: { viewModel.selectBorderEffect(preset: $0, cartItems: $cartItems) }
             )
 
             Spacer()
@@ -61,87 +61,19 @@ struct StyleSelectorView: View {
         }
     }
 
-    // MARK: - 시머/테두리 선택 핸들러 (3-way 분기)
-    /// 시머 프리셋 선택: 무료/보유 → 즉시 적용 / 미보유 유료 → 카트 추가
-    private func handleShimmerSelect(preset: KeyringStylePreset) {
-        let isOwned = StylePresetManager.shared.isOwned(
-            preset: preset,
-            in: .shimmer,
-            userManager: viewModel.userManager
-        )
-        let isUsable = preset.isFree || isOwned
-        let isCurrentlySelected = viewModel.selectedShimmerEffect.activePreset == preset
-
-        if isUsable {
-            // 무료 or 보유 → 즉시 적용 + 카트에서 시머 제거
-            viewModel.updateShimmerEffect(.preset(preset))
-            cartItems.removeAll { $0.type == .shimmerEffect }
-        } else if isCurrentlySelected {
-            // 미보유 유료 + 이미 선택된 상태 → 선택 해제 (silver로 폴백 + 카트 제거)
-            viewModel.updateShimmerEffect(.preset(.silver))
-            cartItems.removeAll { $0.type == .shimmerEffect }
-        } else {
-            // 미보유 유료 + 미선택 → 카트 추가 + 미리보기 적용
-            let price = StylePresetManager.shared.price(for: preset, in: .shimmer)
-            cartItems.removeAll { $0.type == .shimmerEffect }
-            cartItems.append(EffectItem(shimmerEffect: preset, price: price))
-            viewModel.updateShimmerEffect(.preset(preset))
-        }
-    }
-
-    /// 테두리 프리셋 선택: 무료/보유 → 즉시 적용 / 미보유 유료 → 카트 추가
-    private func handleBorderSelect(preset: KeyringStylePreset) {
-        let isOwned = StylePresetManager.shared.isOwned(
-            preset: preset,
-            in: .border,
-            userManager: viewModel.userManager
-        )
-        let isUsable = preset.isFree || isOwned
-        let isCurrentlySelected = viewModel.selectedBorderEffect.activePreset == preset
-
-        if isUsable {
-            viewModel.updateBorderEffect(.preset(preset))
-            cartItems.removeAll { $0.type == .borderEffect }
-        } else if isCurrentlySelected {
-            viewModel.updateBorderEffect(.preset(.silver))
-            cartItems.removeAll { $0.type == .borderEffect }
-        } else {
-            let price = StylePresetManager.shared.price(for: preset, in: .border)
-            cartItems.removeAll { $0.type == .borderEffect }
-            cartItems.append(EffectItem(borderEffect: preset, price: price))
-            viewModel.updateBorderEffect(.preset(preset))
-        }
-    }
-
-    // MARK: - 틴트 색상 바인딩
-    /// ColorPicker ↔ VM 연결: get은 현재 셰이더 색상, set은 .customTint 생성
+    // MARK: - 틴트 색상 바인딩 (VM 메서드를 래핑한 SwiftUI Binding)
+    /// ColorPicker ↔ VM 연결: get/set 모두 VM 메서드 호출만 함
     private func shimmerTintBinding() -> Binding<Color> {
         Binding(
-            get: {
-                let c = viewModel.selectedShimmerEffect.shaderColor
-                return Color(red: Double(c.r), green: Double(c.g), blue: Double(c.b))
-            },
-            set: { newColor in
-                let mode = viewModel.selectedShimmerEffect.activePreset
-                guard mode != .hologram else { return }
-                let c = UIColor(newColor).rgbComponents
-                viewModel.updateShimmerEffect(.customTint(mode: mode, r: c.r, g: c.g, b: c.b))
-            }
+            get: { viewModel.shimmerTintColor() },
+            set: { viewModel.updateShimmerTint(color: $0) }
         )
     }
 
     private func borderTintBinding() -> Binding<Color> {
         Binding(
-            get: {
-                let c = viewModel.selectedBorderEffect.shaderColor
-                return Color(red: Double(c.r), green: Double(c.g), blue: Double(c.b))
-            },
-            set: { newColor in
-                let mode = viewModel.selectedBorderEffect.activePreset
-                guard mode != .hologram else { return }
-                let c = UIColor(newColor).rgbComponents
-                viewModel.updateBorderEffect(.customTint(mode: mode, r: c.r, g: c.g, b: c.b))
-            }
+            get: { viewModel.borderTintColor() },
+            set: { viewModel.updateBorderTint(color: $0) }
         )
     }
 }
@@ -197,7 +129,7 @@ extension StyleSelectorView {
         }
     }
 
-    /// presetCell 래퍼 — Manager 호출로 소유 상태를 계산해 셀에 주입
+    /// presetCell 래퍼 — VM에 소유 상태를 위임하고 셀에 주입
     @ViewBuilder
     private func presetCellWrapper(
         preset: KeyringStylePreset,
@@ -205,11 +137,9 @@ extension StyleSelectorView {
         isSelected: Bool,
         onSelect: @escaping (KeyringStylePreset) -> Void
     ) -> some View {
-        let isOwned = StylePresetManager.shared.isOwned(
-            preset: preset,
-            in: section,
-            userManager: viewModel.userManager
-        )
+        let isOwned = section == .shimmer
+            ? viewModel.isShimmerOwned(preset)
+            : viewModel.isBorderOwned(preset)
 
         presetCell(
             preset: preset,

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/StyleSelectorView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Lenticular/Views/StyleSelectorView.swift
@@ -11,8 +11,10 @@ import SwiftUI
 /// 커스터마이징 하단 영역: "광택 효과" + "테두리" 2섹션
 /// - 왼쪽 ColorPicker: 선택된 프리셋의 틴트 색상 조절 (홀로그램일 때 비활성화)
 /// - 오른쪽 스크롤: 프리셋 선택 (메탈릭 | 홀로그램 | 매트릭스 등)
+/// - 비-silver 프리셋은 유료 → 미보유 시 카트에 추가됨
 struct StyleSelectorView: View {
     @Bindable var viewModel: LenticularVM
+    @Binding var cartItems: [EffectItem]
 
     // 애니메이션 (매트릭스/글리터 미리보기용, +Previews에서 접근)
     @State var matrixPhase: Double = 0
@@ -22,18 +24,20 @@ struct StyleSelectorView: View {
         VStack(alignment: .leading, spacing: 24) {
             styleSection(
                 title: "광택 효과",
+                section: .shimmer,
                 presets: KeyringStylePreset.shimmerPresets,
-                selected: viewModel.selectedShimmerColor,
+                selected: viewModel.selectedShimmerEffect,
                 tintBinding: shimmerTintBinding(),
-                onSelect: { viewModel.updateShimmerColor($0) }
+                onSelect: { handleShimmerSelect(preset: $0) }
             )
 
             styleSection(
                 title: "테두리",
+                section: .border,
                 presets: KeyringStylePreset.borderPresets,
-                selected: viewModel.selectedBorderColor,
+                selected: viewModel.selectedBorderEffect,
                 tintBinding: borderTintBinding(),
-                onSelect: { viewModel.updateBorderColor($0) }
+                onSelect: { handleBorderSelect(preset: $0) }
             )
 
             Spacer()
@@ -57,19 +61,71 @@ struct StyleSelectorView: View {
         }
     }
 
+    // MARK: - 시머/테두리 선택 핸들러 (3-way 분기)
+    /// 시머 프리셋 선택: 무료/보유 → 즉시 적용 / 미보유 유료 → 카트 추가
+    private func handleShimmerSelect(preset: KeyringStylePreset) {
+        let isOwned = StylePresetManager.shared.isOwned(
+            preset: preset,
+            in: .shimmer,
+            userManager: viewModel.userManager
+        )
+        let isUsable = preset.isFree || isOwned
+        let isCurrentlySelected = viewModel.selectedShimmerEffect.activePreset == preset
+
+        if isUsable {
+            // 무료 or 보유 → 즉시 적용 + 카트에서 시머 제거
+            viewModel.updateShimmerEffect(.preset(preset))
+            cartItems.removeAll { $0.type == .shimmerEffect }
+        } else if isCurrentlySelected {
+            // 미보유 유료 + 이미 선택된 상태 → 선택 해제 (silver로 폴백 + 카트 제거)
+            viewModel.updateShimmerEffect(.preset(.silver))
+            cartItems.removeAll { $0.type == .shimmerEffect }
+        } else {
+            // 미보유 유료 + 미선택 → 카트 추가 + 미리보기 적용
+            let price = StylePresetManager.shared.price(for: preset, in: .shimmer)
+            cartItems.removeAll { $0.type == .shimmerEffect }
+            cartItems.append(EffectItem(shimmerEffect: preset, price: price))
+            viewModel.updateShimmerEffect(.preset(preset))
+        }
+    }
+
+    /// 테두리 프리셋 선택: 무료/보유 → 즉시 적용 / 미보유 유료 → 카트 추가
+    private func handleBorderSelect(preset: KeyringStylePreset) {
+        let isOwned = StylePresetManager.shared.isOwned(
+            preset: preset,
+            in: .border,
+            userManager: viewModel.userManager
+        )
+        let isUsable = preset.isFree || isOwned
+        let isCurrentlySelected = viewModel.selectedBorderEffect.activePreset == preset
+
+        if isUsable {
+            viewModel.updateBorderEffect(.preset(preset))
+            cartItems.removeAll { $0.type == .borderEffect }
+        } else if isCurrentlySelected {
+            viewModel.updateBorderEffect(.preset(.silver))
+            cartItems.removeAll { $0.type == .borderEffect }
+        } else {
+            let price = StylePresetManager.shared.price(for: preset, in: .border)
+            cartItems.removeAll { $0.type == .borderEffect }
+            cartItems.append(EffectItem(borderEffect: preset, price: price))
+            viewModel.updateBorderEffect(.preset(preset))
+        }
+    }
+
     // MARK: - 틴트 색상 바인딩
     /// ColorPicker ↔ VM 연결: get은 현재 셰이더 색상, set은 .customTint 생성
     private func shimmerTintBinding() -> Binding<Color> {
         Binding(
             get: {
-                let c = viewModel.selectedShimmerColor.shaderColor
+                let c = viewModel.selectedShimmerEffect.shaderColor
                 return Color(red: Double(c.r), green: Double(c.g), blue: Double(c.b))
             },
             set: { newColor in
-                let mode = viewModel.selectedShimmerColor.activePreset
+                let mode = viewModel.selectedShimmerEffect.activePreset
                 guard mode != .hologram else { return }
                 let c = UIColor(newColor).rgbComponents
-                viewModel.updateShimmerColor(.customTint(mode: mode, r: c.r, g: c.g, b: c.b))
+                viewModel.updateShimmerEffect(.customTint(mode: mode, r: c.r, g: c.g, b: c.b))
             }
         )
     }
@@ -77,14 +133,14 @@ struct StyleSelectorView: View {
     private func borderTintBinding() -> Binding<Color> {
         Binding(
             get: {
-                let c = viewModel.selectedBorderColor.shaderColor
+                let c = viewModel.selectedBorderEffect.shaderColor
                 return Color(red: Double(c.r), green: Double(c.g), blue: Double(c.b))
             },
             set: { newColor in
-                let mode = viewModel.selectedBorderColor.activePreset
+                let mode = viewModel.selectedBorderEffect.activePreset
                 guard mode != .hologram else { return }
                 let c = UIColor(newColor).rgbComponents
-                viewModel.updateBorderColor(.customTint(mode: mode, r: c.r, g: c.g, b: c.b))
+                viewModel.updateBorderEffect(.customTint(mode: mode, r: c.r, g: c.g, b: c.b))
             }
         )
     }
@@ -93,12 +149,13 @@ struct StyleSelectorView: View {
 // MARK: - 섹션 뷰
 extension StyleSelectorView {
     @ViewBuilder
-    private func styleSection(
+    func styleSection(
         title: String,
+        section: StyleSection,
         presets: [KeyringStylePreset],
         selected: KeyringAppearanceColor,
         tintBinding: Binding<Color>,
-        onSelect: @escaping (KeyringAppearanceColor) -> Void
+        onSelect: @escaping (KeyringStylePreset) -> Void
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
@@ -124,8 +181,9 @@ extension StyleSelectorView {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 14) {
                         ForEach(presets) { preset in
-                            presetCell(
+                            presetCellWrapper(
                                 preset: preset,
+                                section: section,
                                 isSelected: selected.activePreset == preset,
                                 onSelect: onSelect
                             )
@@ -139,7 +197,29 @@ extension StyleSelectorView {
         }
     }
 
-    /// 틴트 색상 피커 — 홀로그램 선택 시 비활성화
+    /// presetCell 래퍼 — Manager 호출로 소유 상태를 계산해 셀에 주입
+    @ViewBuilder
+    private func presetCellWrapper(
+        preset: KeyringStylePreset,
+        section: StyleSection,
+        isSelected: Bool,
+        onSelect: @escaping (KeyringStylePreset) -> Void
+    ) -> some View {
+        let isOwned = StylePresetManager.shared.isOwned(
+            preset: preset,
+            in: section,
+            userManager: viewModel.userManager
+        )
+
+        presetCell(
+            preset: preset,
+            isSelected: isSelected,
+            isOwned: isOwned,
+            onSelect: onSelect
+        )
+    }
+
+    /// 틴트 색상 피커 — 홀로그램 선택 시 비활성화 (silver만 보유해도 항상 활성화)
     @ViewBuilder
     private func tintPickerView(
         selected: KeyringAppearanceColor,
@@ -177,5 +257,3 @@ extension StyleSelectorView {
         }
     }
 }
-
-


### PR DESCRIPTION
## 🎯 PR 내용

### 렌티큘러 키링 프리셋 유료화 + 관련 버그/UX 개선.

**핵심 변경**
- silver는 기본 무료, hologram(시머) 1000코인, 그 외 프리셋 500코인
- 미보유 프리셋 클릭 → 카트에 자동 추가 → "다음" 버튼이 "구매 N"으로 변경
- 시머 / 테두리 / 사운드 / 파티클을 한 카트에 담아 한 번에 결제
- 가격은 Firestore 컬렉션에서 로드 (운영자가 가격 조정 가능, 실패 시 코드 fallback)
- 결제 성공 시 모든 카트 아이템에 대해 `Receipts` 서브컬렉션에 영수증 기록 
> 사운드/파티클도 구매내역 기록 로직이 없길래, 이번에 미리 추가하였음.
> 아마 유료템이 없어서 구현하지 않은듯.

**부수 개선**
- `composeAtlas` assertion 제거 — 사진 미편집 상태로 진입할 때 크래시가 있었다.
- `StyleSelectorView`의 비즈니스 로직을 `LenticularVM+Style.swift`로 이동 (MVVM 정리)

## 📱 스크린샷 (UI 변경 시)


https://github.com/user-attachments/assets/8eafdc28-84ea-49e7-977e-83d9f9368299

> 유료표시 -> 내가 없는 템 
구매하면 유료표시 사라짐. 
이정도만 해도 직관적인듯함. 어차피 아이템이 많진 않아서.

## 🔗 관련 이슈
- #195 

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
