### PR TITLE
feat: 렌티큘러 GIF 프리뷰 지원 및 템플릿 프리뷰 MVVM 리팩토링

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		4C7E96502F89212100C8B109 /* ColorChipSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7E964D2F89212100C8B109 /* ColorChipSelector.swift */; };
 		4C7E96622F8BD98F00C8B109 /* BMDOHYEON_otf.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4C7E96602F8BD98F00C8B109 /* BMDOHYEON_otf.otf */; };
 		4C7E96632F8BD98F00C8B109 /* esamanru OTF Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4C7E96612F8BD98F00C8B109 /* esamanru OTF Medium.otf */; };
+		4C7E96682F8CFA3000C8B109 /* TemplatePreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7E96662F8CFA3000C8B109 /* TemplatePreviewViewModel.swift */; };
 		4C8426602ED3585A0050B6FE /* gulimche-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4C84265F2ED3585A0050B6FE /* gulimche-Regular.ttf */; };
 		4C8426642ED375840050B6FE /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8426632ED375840050B6FE /* ColorPalette.swift */; };
 		4C84A1602EB134BD008FFE57 /* ProfileSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A596832EAFEAA20003D712 /* ProfileSetupView.swift */; };
@@ -1048,6 +1049,7 @@
 		4C7E964E2F89212100C8B109 /* ColorPaletteRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPaletteRow.swift; sourceTree = "<group>"; };
 		4C7E96602F8BD98F00C8B109 /* BMDOHYEON_otf.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = BMDOHYEON_otf.otf; sourceTree = "<group>"; };
 		4C7E96612F8BD98F00C8B109 /* esamanru OTF Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "esamanru OTF Medium.otf"; sourceTree = "<group>"; };
+		4C7E96662F8CFA3000C8B109 /* TemplatePreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplatePreviewViewModel.swift; sourceTree = "<group>"; };
 		4C84265F2ED3585A0050B6FE /* gulimche-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "gulimche-Regular.ttf"; sourceTree = "<group>"; };
 		4C8426632ED375840050B6FE /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		4C86A6112F25C0B10023AA2D /* WorkshopBundleGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkshopBundleGridView.swift; sourceTree = "<group>"; };
@@ -1829,6 +1831,7 @@
 				4C47333A2F1FA388005D2376 /* Components */,
 				4C47333C2F1FA388005D2376 /* Models */,
 				4C47334B2F1FA388005D2376 /* Views */,
+				4C7E96672F8CFA3000C8B109 /* ViewModels */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2348,6 +2351,14 @@
 				4C7E96612F8BD98F00C8B109 /* esamanru OTF Medium.otf */,
 			);
 			path = Uniform;
+			sourceTree = "<group>";
+		};
+		4C7E96672F8CFA3000C8B109 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				4C7E96662F8CFA3000C8B109 /* TemplatePreviewViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		4C84265E2ED358520050B6FE /* Gulim */ = {
@@ -3608,6 +3619,7 @@
 				3822DDC22EBBC712003125BE /* KeyringEditView.swift in Sources */,
 				4CF2A9662F0B8C5800BA9FDA /* PullToRefreshIndicator.swift in Sources */,
 				4C4734002F22615D005D2376 /* WorkshopItemCard.swift in Sources */,
+				4C7E96682F8CFA3000C8B109 /* TemplatePreviewViewModel.swift in Sources */,
 				4C4734012F22615D005D2376 /* WorkshopFilterBar.swift in Sources */,
 				4C4734022F22615D005D2376 /* WorkshopFilterChip.swift in Sources */,
 				4C4734032F22615D005D2376 /* WorkshopItemActionButton.swift in Sources */,

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
@@ -196,6 +196,12 @@ extension TemplatePreviewBody {
                     )
                         .scaledToFit()
                         .frame(width: 386, height: 386)
+                } else if template.previewURL.contains(".gif") {
+                    // GIF URL인 경우 애니메이션 재생 (렌티큘러 등)
+                    // Firebase Storage URL은 쿼리 파라미터가 붙어 hasSuffix 불가 → contains 사용
+                    SimpleAnimatedImage(url: template.previewURL, maxSize: CGSize(width: 400, height: 400))
+                        .scaledToFit()
+                        .frame(width: 386, height: 386)
                 } else {
                     ItemDetailImage(itemURL: template.previewURL)
                         .scaledToFit()

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Components/TemplatePreviewComponents.swift
@@ -18,26 +18,10 @@ struct TemplatePreviewBody: View {
     var router: NavigationRouter<WorkshopRoute>? = nil
 
     @Environment(UserManager.self) private var userManager
-
-    // 구매 관련 상태
-    @State private var showPurchaseSheet = false
-    @State private var purchasePopupScale: CGFloat = 0.3
-    @State private var showPurchasingLoading = false
-    @State private var showPurchaseSuccessAlert = false
-    @State private var showPurchaseFailAlert = false
-    @State private var purchaseFailScale: CGFloat = 0.3
-    
-    // 보관함 용량 관련
-    @State private var showInvenFullAlert: Bool = false
-
-    /// 템플릿 보유 여부 확인
-    private var isOwned: Bool {
-        guard let user = userManager.currentUser,
-              let templateId = template?.id else { return false }
-        return user.templates.contains(templateId)
-    }
+    @State private var viewModel = TemplatePreviewViewModel()
 
     var body: some View {
+        @Bindable var viewModel = viewModel
         ZStack {
             if template == nil {
                 // fetch 중 — 로딩 인디케이터만 표시
@@ -68,7 +52,7 @@ struct TemplatePreviewBody: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            
+
             CustomNavigationBar {
                 BackToolbarButton {
                     TabBarManager.show()
@@ -83,8 +67,8 @@ struct TemplatePreviewBody: View {
         .ignoresSafeArea()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationBarBackButtonHidden(true)
-        .blur(radius: (showPurchasingLoading || showPurchaseSuccessAlert) ? 10 : 0)
-        .animation(.easeInOut(duration: 0.3), value: (showPurchasingLoading || showPurchaseSuccessAlert))
+        .blur(radius: (viewModel.showPurchasingLoading || viewModel.showPurchaseSuccessAlert) ? 10 : 0)
+        .animation(.easeInOut(duration: 0.3), value: (viewModel.showPurchasingLoading || viewModel.showPurchaseSuccessAlert))
         .withToast(position: .button)
         .onAppear {
             TabBarManager.hide()
@@ -95,16 +79,11 @@ struct TemplatePreviewBody: View {
         .overlay {
             ZStack(alignment: .center) {
                 // 구매 확인 팝업
-                if showPurchaseSheet {
+                if viewModel.showPurchaseSheet {
                     Color.black20
                         .ignoresSafeArea()
                         .onTapGesture {
-                            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
-                                purchasePopupScale = 0.3
-                            }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                                showPurchaseSheet = false
-                            }
+                            Task { await viewModel.dismissPurchasePopup() }
                         }
 
                     if let template {
@@ -112,10 +91,13 @@ struct TemplatePreviewBody: View {
                             title: template.name,
                             myCoin: userManager.currentUser?.coin ?? 0,
                             price: template.workshopPrice,
-                            scale: purchasePopupScale,
+                            scale: viewModel.purchasePopupScale,
                             onConfirm: {
                                 Task {
-                                    await handlePurchase()
+                                    await viewModel.handlePurchase(
+                                        template: template,
+                                        userManager: userManager
+                                    )
                                 }
                             }
                         )
@@ -125,45 +107,37 @@ struct TemplatePreviewBody: View {
                 }
 
                 // 구매 중 로딩
-                if showPurchasingLoading {
+                if viewModel.showPurchasingLoading {
                     LoadingAlert(type: .short40, message: nil)
                 }
 
                 // 구매 성공 알림
-                if showPurchaseSuccessAlert {
+                if viewModel.showPurchaseSuccessAlert {
                     KeychyAlert(
                         type: .checkmark,
                         message: "구매 완료!",
-                        isPresented: $showPurchaseSuccessAlert
+                        isPresented: $viewModel.showPurchaseSuccessAlert
                     )
                 }
 
                 // TODO: - 구버전 Alert 사용중, Popup으로 전환 필요
                 // 구매 실패 알림 (코인 부족)
-                if showPurchaseFailAlert {
+                if viewModel.showPurchaseFailAlert {
                     Color.black.opacity(0.4)
                         .ignoresSafeArea()
                         .onTapGesture {}
 
                     BangmarkAlert(
-                        checkmarkScale: purchaseFailScale,
+                        checkmarkScale: viewModel.purchaseFailScale,
                         text: "코인이 부족해요",
                         cancelText: "취소",
                         confirmText: "충전하기",
                         onCancel: {
-                            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
-                                purchaseFailScale = 0.3
-                            }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                                showPurchaseFailAlert = false
-                            }
+                            Task { await viewModel.dismissPurchaseFailAlert() }
                         },
                         onConfirm: {
-                            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
-                                purchaseFailScale = 0.3
-                            }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                                showPurchaseFailAlert = false
+                            Task {
+                                await viewModel.dismissPurchaseFailAlert()
                                 router?.push(.coinCharge)
                             }
                         }
@@ -171,9 +145,9 @@ struct TemplatePreviewBody: View {
                     .padding(.horizontal, 40)
                     .padding(.bottom, 30)
                 }
-                
-                if showInvenFullAlert {
-                    InvenLackPopup(isPresented: $showInvenFullAlert)
+
+                if viewModel.showInvenFullAlert {
+                    InvenLackPopup(isPresented: $viewModel.showInvenFullAlert)
                 }
             }
             .frame(maxHeight: .infinity)
@@ -227,100 +201,14 @@ extension TemplatePreviewBody {
             if let template {
                 TemplateActionButton(
                     template: template,
-                    isOwned: isOwned,
-                    onMake: checkInventoryAndMake,
+                    isOwned: viewModel.isOwned(template: template, user: userManager.currentUser),
+                    onMake: {
+                        viewModel.checkInventoryAndMake(userManager: userManager, onMake: onMake)
+                    },
                     onPurchase: onPurchase ?? {
-                        // 네트워크 체크
-                        guard NetworkManager.shared.isConnected else {
-                            ToastManager.shared.show()
-                            return
-                        }
-
-                        showPurchaseSheet = true
-                        withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
-                            purchasePopupScale = 1.0
-                        }
+                        viewModel.showPurchasePopup()
                     }
                 )
-            }
-        }
-    }
-
-    /// 구매 처리
-    private func handlePurchase() async {
-        guard let template = template else { return }
-
-        // 팝업 닫기 애니메이션
-        await MainActor.run {
-            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
-                purchasePopupScale = 0.3
-            }
-        }
-
-        try? await Task.sleep(nanoseconds: 200_000_000)
-
-        await MainActor.run {
-            showPurchaseSheet = false
-        }
-
-        try? await Task.sleep(nanoseconds: 100_000_000)
-
-        // 로딩 시작
-        await MainActor.run {
-            showPurchasingLoading = true
-        }
-
-        // ItemPurchaseManager를 통해 구매 처리
-        let result = await ItemPurchaseManager.shared.purchaseWorkshopItem(template, userManager: userManager)
-
-        // 로딩 종료
-        await MainActor.run {
-            showPurchasingLoading = false
-        }
-
-        try? await Task.sleep(nanoseconds: 100_000_000)
-
-        switch result {
-        case .success:
-            // 성공 시 성공 알림 표시
-            showPurchaseSuccessAlert = true
-
-        case .insufficientCoins:
-            // 코인 부족 시 실패 알림 표시
-            showPurchaseFailAlert = true
-            withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
-                purchaseFailScale = 1.0
-            }
-
-        case .failed(let message):
-            // 기타 실패 시 에러 출력
-            print("구매 실패: \(message)")
-        }
-    }
-    
-    /// 보관함 용량 체크 후 만들기 실행
-    private func checkInventoryAndMake() {
-        // 네트워크 체크
-        guard NetworkManager.shared.isConnected else {
-            ToastManager.shared.show()
-            return
-        }
-
-        guard let userId = userManager.currentUser?.id else { return }
-
-        // CollectionViewModel의 용량 체크 메서드 사용
-        let collectionVM = CollectionViewModel()
-        collectionVM.checkInventoryCapacity(userId: userId) { hasSpace in
-            DispatchQueue.main.async {
-                if hasSpace {
-                    // 보관함에 여유 있음 -> onMake 실행
-                    self.onMake()
-                } else {
-                    // 보관함 가득 참 -> 알럿 표시
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                        self.showInvenFullAlert = true
-                    }
-                }
             }
         }
     }

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/ViewModels/TemplatePreviewViewModel.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/ViewModels/TemplatePreviewViewModel.swift
@@ -1,0 +1,131 @@
+//
+//  TemplatePreviewViewModel.swift
+//  Keychy
+//
+//  Created by 길지훈 on 2026-04-13.
+//
+
+import SwiftUI
+import FirebaseFirestore
+
+/// TemplatePreviewBody의 구매/보관함 비즈니스 로직 담당
+@Observable
+@MainActor
+final class TemplatePreviewViewModel {
+    // MARK: - 구매 관련 상태
+    var showPurchaseSheet = false
+    var purchasePopupScale: CGFloat = 0.3
+    var showPurchasingLoading = false
+    var showPurchaseSuccessAlert = false
+    var showPurchaseFailAlert = false
+    var purchaseFailScale: CGFloat = 0.3
+
+    // MARK: - 보관함 용량 관련
+    var showInvenFullAlert = false
+
+    // MARK: - 템플릿 보유 여부
+    func isOwned(template: KeyringTemplate?, user: KeychyUser?) -> Bool {
+        guard let user, let templateId = template?.id else { return false }
+        return user.templates.contains(templateId)
+    }
+
+    // MARK: - 구매 팝업 표시
+    func showPurchasePopup() {
+        guard NetworkManager.shared.isConnected else {
+            ToastManager.shared.show()
+            return
+        }
+        showPurchaseSheet = true
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+            purchasePopupScale = 1.0
+        }
+    }
+
+    // MARK: - 구매 팝업 닫기
+    func dismissPurchasePopup() async {
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+            purchasePopupScale = 0.3
+        }
+        try? await Task.sleep(for: .seconds(0.2))
+        showPurchaseSheet = false
+    }
+
+    // MARK: - 구매 처리
+    func handlePurchase(template: KeyringTemplate, userManager: UserManager) async {
+        await dismissPurchasePopup()
+        try? await Task.sleep(for: .seconds(0.1))
+
+        showPurchasingLoading = true
+
+        // ItemPurchaseManager를 통해 구매 처리
+        let result = await ItemPurchaseManager.shared.purchaseWorkshopItem(
+            template,
+            userManager: userManager
+        )
+
+        showPurchasingLoading = false
+        try? await Task.sleep(for: .seconds(0.1))
+
+        switch result {
+        case .success:
+            showPurchaseSuccessAlert = true
+        case .insufficientCoins:
+            showPurchaseFailAlert = true
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                purchaseFailScale = 1.0
+            }
+        case .failed(let message):
+            print("구매 실패: \(message)")
+        }
+    }
+
+    // MARK: - 보관함 체크 후 만들기
+    func checkInventoryAndMake(userManager: UserManager, onMake: @escaping () -> Void) {
+        guard NetworkManager.shared.isConnected else {
+            ToastManager.shared.show()
+            return
+        }
+        guard let userId = userManager.currentUser?.id else { return }
+
+        Task {
+            let hasSpace = await checkInventoryCapacity(userId: userId)
+            if hasSpace {
+                onMake()
+            } else {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    showInvenFullAlert = true
+                }
+            }
+        }
+    }
+
+    // MARK: - 구매 실패 팝업 닫기
+    func dismissPurchaseFailAlert() async {
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+            purchaseFailScale = 0.3
+        }
+        try? await Task.sleep(for: .seconds(0.2))
+        showPurchaseFailAlert = false
+    }
+
+    // MARK: - Firebase 보관함 용량 확인
+    /// CollectionViewModel 인스턴스 없이 직접 Firestore 조회 (async/await)
+    private func checkInventoryCapacity(userId: String) async -> Bool {
+        do {
+            let snapshot = try await Firestore.firestore()
+                .collection("User")
+                .document(userId)
+                .getDocument()
+
+            guard let data = snapshot.data(),
+                  let keyrings = data["keyrings"] as? [String],
+                  let maxKeyringCount = data["maxKeyringCount"] as? Int else {
+                return false
+            }
+
+            return keyrings.count < maxKeyringCount
+        } catch {
+            return false
+        }
+    }
+}

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Uniform/ViewModels/UniformVM+Frame.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Uniform/ViewModels/UniformVM+Frame.swift
@@ -124,11 +124,11 @@ extension UniformVM {
         if charCount <= 4 {
             adjustedFontSize = baseFontSize
         } else if charCount <= 6 {
-            adjustedFontSize = baseFontSize * 0.8
+            adjustedFontSize = baseFontSize * 0.85
         } else if charCount <= 8 {
-            adjustedFontSize = baseFontSize * 0.65
+            adjustedFontSize = baseFontSize * 0.72
         } else {
-            adjustedFontSize = baseFontSize * 0.55
+            adjustedFontSize = baseFontSize * 0.62
         }
 
         let nameFont = UIFont(name: FontFamily.esamanruMedium.fontName, size: adjustedFontSize)
@@ -138,7 +138,7 @@ extension UniformVM {
         let normalized = (textCurvature - 0.16) / (0.84 - 0.16)
 
         // 중간 이상 곡률에서 이름을 위로 올려 등번호와 겹침 방지
-        let nameUpshift: CGFloat = max(normalized - 0.3, 0) / 0.7 * 10.0
+        let nameUpshift: CGFloat = max(normalized - 0.3, 0) / 0.7 * 14.0
         let adjustedNameOffsetY = nameOffsetY - nameUpshift
 
         if normalized < 0.01 {

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Uniform/Views/UniformCompositionView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Uniform/Views/UniformCompositionView.swift
@@ -128,9 +128,9 @@ struct UniformCompositionView: View {
             let count = viewModel.playerNameText.count
             let base = viewModel.nameFontSize
             if count <= 4 { return base }
-            else if count <= 6 { return base * 0.8 }
-            else if count <= 8 { return base * 0.65 }
-            else { return base * 0.55 }
+            else if count <= 6 { return base * 0.85 }
+            else if count <= 8 { return base * 0.72 }
+            else { return base * 0.62 }
         }()
 
         VStack(spacing: 0) {
@@ -152,7 +152,7 @@ struct UniformCompositionView: View {
             let normalized = (viewModel.textCurvature - 0.16) / (0.84 - 0.16)
 
             // 중간 이상 곡률에서 이름을 위로 올려 등번호와 겹침 방지
-            let nameUpshift: CGFloat = max(normalized - 0.3, 0) / 0.7 * 10.0
+            let nameUpshift: CGFloat = max(normalized - 0.3, 0) / 0.7 * 14.0
             let adjustedNameOffsetY = nameOffsetY - nameUpshift
 
             if normalized < 0.01 {
@@ -174,7 +174,7 @@ struct UniformCompositionView: View {
                     innerColor: viewModel.nameInnerColor,
                     outlineColor: viewModel.nameOutlineColor
                 )
-                .frame(width: 280, height: 80)
+                .frame(width: 320, height: 90)
                 .offset(y: adjustedNameOffsetY)
             }
         }


### PR DESCRIPTION
## 🎯 PR 내용

**렌티큘러 키링 GIF 프리뷰 지원 + 템플릿 프리뷰 MVVM 리팩토링**

- 렌티큘러처럼 움직이는 키링은 정적 이미지 대신 **GIF 애니메이션**으로 프리뷰 표시
  - `previewURL`에 `.gif`가 포함되면 기존 `SimpleAnimatedImage`로 분기 (Nuke 캐싱 + CGImageSource 프레임 파싱)
  - Firebase Storage URL은 `?alt=media&token=...`이 붙어서 `hasSuffix` 대신 `contains`로 판별
- `TemplatePreviewBody` 안에 직접 들어있던 구매/보관함 로직을 `TemplatePreviewViewModel`로 분리
  - `DispatchQueue.main.asyncAfter` 콜백 → `async/await` + `Task.sleep(for:)`로 교체
- 유니폼 템플릿 최대곡률/폰트사이즈 미세 조정

## 📱 스크린샷 (UI 변경 시)

https://github.com/user-attachments/assets/b2a68621-9dd0-4294-8e1c-b676ec2d7ef7


## 🔗 관련 이슈

- #204 

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
