### PR TITLE
fix: 유니폼 basket 6자 제한 + TestFlight isActive 레이스 컨디션 수정

### DIFF
--- a/Keychy/Keychy/App/AppDelegate.swift
+++ b/Keychy/Keychy/App/AppDelegate.swift
@@ -55,8 +55,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Firebase 초기화
         FirebaseApp.configure()
 
-        // 빌드 환경 판별 (Debug/TestFlight vs App Store)
-        Task { await BuildEnvironment.configure() }
+        // 빌드 환경 판별은 RootViewModel.checkAuthAndNavigate()에서 await로 보장
 
         // TabBar 외형 설정
         configureTabBarAppearance()

--- a/Keychy/Keychy/Presentation/Intro/ViewModels/RootViewModel.swift
+++ b/Keychy/Keychy/Presentation/Intro/ViewModels/RootViewModel.swift
@@ -50,6 +50,9 @@ class RootViewModel {
     /// 앱 업데이트 체크 후 사용자 인증 상태를 확인하고 적절한 화면으로 라우팅
     func checkAuthAndNavigate() {
         Task {
+            // 0. 빌드 환경 판별 완료 대기 (TestFlight에서 isActive 필터 오동작 방지)
+            await BuildEnvironment.configure()
+
             // 1. 앱 업데이트 체크
             await updateManager.checkForUpdate()
 

--- a/Keychy/Keychy/Presentation/KeyringMaker/Templates/Uniform/ViewModels/UniformVM.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Templates/Uniform/ViewModels/UniformVM.swift
@@ -107,10 +107,12 @@ class UniformVM: KeyringViewModelProtocol {
 
     // MARK: - 마킹 입력 검증
 
-    /// 선수 이름 입력값 검증 (8자 제한)
+    /// 선수 이름 입력값 검증 (uniformType에 따라 글자 수 제한)
     func validatePlayerName(_ newValue: String) {
-        if newValue.count > 10 {
-            playerNameText = String(newValue.prefix(10))
+        // basket(농구)은 텍스트 영역이 좁아 6자, 나머지는 10자
+        let limit = selectedFrame?.uniformType == "basket" ? 6 : 10
+        if newValue.count > limit {
+            playerNameText = String(newValue.prefix(limit))
         }
     }
 


### PR DESCRIPTION
## 🎯 PR 내용

- **basket 유니폼 글자 수 제한**: 농구 유니폼은 텍스트 영역이 좁아서 선수 이름을 6자로 제한 (기본 타입은 기존 10자 유지)
> ++ 텍스트 위치, base 타입과 다르게 살짝 아래에서 등장

- **TestFlight 템플릿 누락 수정**: `BuildEnvironment.configure()`가 fire-and-forget으로 실행되어 템플릿 fetch 시점에 환경 판별이 안 끝난 경우가 있었음.

 **비유**: 식당 문 열기 전에 "오늘의 메뉴판"을 걸어야 하는데, 
 메뉴판 준비를 다른 직원에게 맡기고(fire-and-forget) 바로 문을 열어버려서 손님마다 메뉴판이 보이기도/안 보이기도 했음. 
 이제 메뉴판 준비가 끝난 뒤에 문을 열도록 수정.

## 🔗 관련 이슈

- #211 

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
