### PR TITLE
feat: [유니폼 템플릿] - 키보드 업~ 시트 업~

### DIFF
--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -3983,7 +3983,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BUKGH5MWAT;
 				ENABLE_PREVIEWS = YES;
@@ -4032,7 +4032,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BUKGH5MWAT;
 				ENABLE_PREVIEWS = YES;
@@ -4081,7 +4081,7 @@
 				CODE_SIGN_ENTITLEMENTS = WidgetKeychy/WidgetKeychyExtension.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BUKGH5MWAT;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -4124,7 +4124,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BUKGH5MWAT;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView.swift
@@ -28,6 +28,8 @@ struct KeyringCustomizingView<VM: KeyringViewModelProtocol>: View {
     @State private var bottomViewOpacity: Double = 0  // 하단 영역 opacity
     @State private var bottomViewOffset: CGFloat = 30  // 하단 영역 offset
     @State private var currentBottomViewHeightRatio: CGFloat = 0.35  // 현재 하단 뷰 높이 비율
+    @State private var keyboardHeight: CGFloat = 0  // 키보드 표시 여부 판단용
+    @State private var keyboardHideTask: Task<Void, Never>?  // 키보드 hide 디바운스용
 
     // 구매 시트
     @State var showPurchaseSheet = false
@@ -169,6 +171,28 @@ struct KeyringCustomizingView<VM: KeyringViewModelProtocol>: View {
             .animation(.easeOut(duration: 0.3), value: isLoadingResources)
             .animation(.easeOut(duration: 0.3), value: isSceneReady)
             .animation(.easeOut(duration: 0.3), value: showPurchaseFailAlert)
+            // 키보드 표시 시 시트 높이 동적 조정
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+                // 텍스트필드 전환 시 pending된 hide 취소 (숫자패드↔텍스트 키보드 전환 떨림 방지)
+                keyboardHideTask?.cancel()
+                let baseRatio = viewModel.bottomViewHeightRatio(for: selectedMode)
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    currentBottomViewHeightRatio = baseRatio + 0.2
+                }
+                keyboardHeight = 1
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                // 50ms 디바운스: 텍스트필드 간 포커스 이동 시 willHide→willShow 연속 발생 대응
+                keyboardHideTask?.cancel()
+                keyboardHideTask = Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                    guard !Task.isCancelled else { return }
+                    keyboardHeight = 0
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        currentBottomViewHeightRatio = viewModel.bottomViewHeightRatio(for: selectedMode)
+                    }
+                }
+            }
 
             // MARK: - 커스텀 네비게이션 바
             customNavigationBar
@@ -223,6 +247,13 @@ struct KeyringCustomizingView<VM: KeyringViewModelProtocol>: View {
             purchaseSheet
         }
         .onChange(of: selectedMode) { oldMode, newMode in
+            // 모드 전환 시 키보드 닫기 (키보드가 떠있으면 willHide에서 비율 복원되므로 여기선 직접 처리)
+            UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder),
+                to: nil, from: nil, for: nil
+            )
+            keyboardHeight = 0
+
             // 첫 진입 이후 모드 전환 시 애니메이션 비활성화
             isInitialBottomViewAppear = false
 

--- a/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView.swift
+++ b/Keychy/Keychy/Presentation/KeyringMaker/Shared/Views/KeyringCustomizingView.swift
@@ -73,6 +73,8 @@ struct KeyringCustomizingView<VM: KeyringViewModelProtocol>: View {
                     .environment(\.previewScaleFactor, previewScale)
                     .environment(\.previewTopPadding, topPadding)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .scaleEffect(keyboardHeight > 0 ? 0.6 : 1.0, anchor: .top)
+                    .animation(.easeInOut(duration: 0.25), value: keyboardHeight)
                     .contentShape(Rectangle())
                     .simultaneousGesture(
                         TapGesture().onEnded {


### PR DESCRIPTION
## 🎯 PR 내용

유니폼 마킹 탭에서 텍스트 입력 시 키보드가 시트를 가리던 문제 해결.

- 키보드 `willShow`/`willHide` 알림으로 시트 높이 동적 조정 (+20%)
- 키링 씬을 `scaleEffect(0.6, anchor: .top)`으로 축소하여 시트에 가려지지 않도록 처리
- 텍스트필드 간 전환 시(선수이름→등번호) 시트 떨림 방지: `willHide`에 50ms 디바운스 적용
- 모드 탭 전환 시 키보드 자동 dismiss + 시트 높이 복원
- `빌드 버전 18 → 21`

## 📱 스크린샷 (UI 변경 시)

https://github.com/user-attachments/assets/10e2020b-c109-44e8-a061-b84c3f012e45

> 유니폼 마킹 탭 — 선수이름/등번호 TextField 포커스 시 시트가 올라가고 키링이 축소된 모습

## 🔗 관련 이슈

- #226 

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
