### PR TITLE
fix(bundle): 완성뷰 스와이프 백 제스처 차단

### DIFF
--- a/Keychy/Keychy/Presentation/Bundle/Views/Complete/BundleCompleteView.swift
+++ b/Keychy/Keychy/Presentation/Bundle/Views/Complete/BundleCompleteView.swift
@@ -60,6 +60,8 @@ struct BundleCompleteView<Route: BundleRoute>: View {
         }
         .ignoresSafeArea()
         .navigationBarBackButtonHidden()
+        // 완성뷰에선 스와이프 백 제스처도 차단 (뒤로가기 자체 불가)
+        .swipeBackGesture(enabled: false)
         .toolbar {
             closeToolbarItem
             titleToolbarItem


### PR DESCRIPTION
## 🎯 PR 내용

뭉치 완성뷰(`BundleCompleteView`)에서 **스와이프로 뒤로가기**가 가능했던 버그 수정.

**원인**:
- `.navigationBarBackButtonHidden()`은 **뒤로가기 버튼만 숨길 뿐**, 
iOS의 인터랙티브 pop 제스처는 그대로 살아있음 (Apple의 함정 — 둘이 분리된 개념)

**수정**:
- 프로젝트에 이미 있는 `swipeBackGesture(enabled:)` 헬퍼 사용 (`CollectionKeyringDetailView`, `KeyringCustomizingView`와 동일 패턴)

```swift
.ignoresSafeArea()
.navigationBarBackButtonHidden()
// 완성뷰에선 스와이프 백 제스처도 차단 (뒤로가기 자체 불가)
.swipeBackGesture(enabled: false)
```

## 📱 스크린샷 (UI 변경 시)

[UI 변경 없음 — 제스처 동작만 변경]

## 🔗 관련 이슈

-

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료
