### PR TITLE
fix(fastlane): sync_build_number 경로 해석 수정 (#240 hotfix)

### DIFF
--- a/Keychy/fastlane/Fastfile
+++ b/Keychy/fastlane/Fastfile
@@ -18,7 +18,11 @@ platform :ios do
     build_num = Time.now.strftime("%y%m%d%H%M")
     targets_to_sync = %w[Keychy WidgetKeychyExtension MessageKeychy]
 
-    project = Xcodeproj::Project.open("Keychy.xcodeproj")
+    # private_lane 안에선 CWD 가 fastlane/ 라서 "Keychy.xcodeproj" 로는 못 찾음
+    # Fastfile 기준 절대 경로로 해석 (.. = fastlane 의 부모 = Keychy 폴더)
+    project_path = File.expand_path("../Keychy.xcodeproj", __dir__)
+
+    project = Xcodeproj::Project.open(project_path)
     project.targets.each do |target|
       next unless targets_to_sync.include?(target.name)
       target.build_configurations.each do |config|


### PR DESCRIPTION
## 🎯 PR 내용

PR #240 (`sync_build_number` private_lane 추가) 직후 CI 가 `Xcodeproj` 못 찾는 에러로 실패한 거 hotfix.

### 원인

```
[Xcodeproj] Unable to open .../Keychy/fastlane/Keychy.xcodeproj
because it doesn't exist
```

`private_lane` 안에서 CWD 가 `fastlane/` 폴더로 잡힘. 거기서 `"Keychy.xcodeproj"` 찾으니까 `Keychy/fastlane/Keychy.xcodeproj` 가 됨 (없음).

fastlane 내장 액션(`build_app`, `update_code_signing_settings`)은 알아서 경로 보정해주는데, 직접 `Xcodeproj` gem 호출하면 그 보정이 없음.

### 수정

`__dir__` (Fastfile 경로) 기준 절대 경로로 해석:

```ruby
project_path = File.expand_path("../Keychy.xcodeproj", __dir__)
project = Xcodeproj::Project.open(project_path)
```

## 📱 스크린샷 (UI 변경 시)

[UI 변경 없음 — 파이프라인 수정]

## 🔗 관련 이슈

- #240

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료