### PR TITLE
chore(ci): Xcode 26.0.1 핀으로 위젯 동작 회복

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # 1.5. Xcode 26.0.1 핀
+      # ClockHandRotationEffect 라이브러리가 비공개 API (_ClockHandRotationEffect)
+      # 를 사용하는데, Xcode 26.1+ 에서 이 API 가 깨져 위젯 시계 바늘 애니메이션이
+      # 동작하지 않음 (GitHub Issue #11). 26.0.1 로 핀해 회피.
+      # 라이브러리 측에 새 시그니처 대응 PR 머지되면 핀 해제 가능.
+      - name: Select Xcode 26.0.1
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.0.1'
+
       # 2. 배포 lane 결정 (브랜치 자동 / 수동 선택)
       - name: Determine deploy lane
         id: lane

--- a/Keychy/Keychy.xcodeproj/project.pbxproj
+++ b/Keychy/Keychy.xcodeproj/project.pbxproj
@@ -4449,7 +4449,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Keychy/KeychyRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -4476,7 +4476,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = KeychyApp;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "KeychyApp Distribution";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -4498,7 +4498,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = WidgetKeychy/WidgetKeychyExtension.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -4516,7 +4516,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app.WidgetKeychy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "keychy-widget";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "KeychyApp Widget Distribution";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -4541,7 +4541,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = WidgetKeychy/WidgetKeychyExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -4559,7 +4559,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.KeychyOfficial.app.WidgetKeychy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "keychy-widget";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "KeychyApp Widget Distribution";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
## 🎯 PR 내용

CI 빌드의 위젯 시계 바늘이 깨지는 문제 해결.

**비유**: 옛날 도서관 카드(라이브러리)로 새로 바뀐 지문 인식 입구(Xcode 26.1+ SDK)를 통과하려니 막힘. 
옛날 입구를 그대로 유지하는 도서관(Xcode 26.0.1)으로 우회..!!!.

### 원인

- 위젯이 `ClockHandRotationKit` 라이브러리 사용 (시계 바늘 회전 효과)
> 당시 모든 이슈를 중국어 -> 한국어 번역해서 봤는데 이건 제대로 못봤던듯

- 이 라이브러리는 비공개 API `_ClockHandRotationEffect` 호출
- **Xcode 26.1+ 에서 이 비공개 API 의 내부 구현이 변경**돼 호출이 깨짐 (참고: octree/ClockHandRotationKit Issue #11)
- 로컬 수동 archive (Xcode 26.0.1) → 위젯 정상
- CI (macos-26 runner 기본 Xcode 26.4.1) → 위젯 시계 바늘 안 돌아감

### 검증된 데이터

| 환경 | Xcode | 위젯 |
|---|---|---|
| 수동 archive | 26.0.1 | ✅ 정상 |
| CI (현재) | 26.4.1 | ❌ 버벅 |

### 수정

`maxim-lobanov/setup-xcode@v1` 액션으로 Xcode 26.0.1 명시:

```yaml
- name: Select Xcode 26.0.1
  uses: maxim-lobanov/setup-xcode@v1
  with:
    xcode-version: '26.0.1'
```

체크아웃 직후, lane 결정 전에 배치.

### 후속 작업

- ClockHandRotationKit 메인테이너가 Xcode 26.1+ 새 시그니처 대응 PR 머지하면 핀 해제 가능
- 또는 자체 SwiftUI 구현으로 라이브러리 의존성 끊기 (장기)

## 📱 스크린샷 (UI 변경 시)

[UI 변경 없음 — CI 환경 변경]

## 🔗 관련 이슈

-

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 테스트 완료
- [x] Self-review 완료